### PR TITLE
fix: validator announce reverse endian

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlane_starknet"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alexandria_bytes",
  "openzeppelin",

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyperlane_starknet"
 description = "Implementation of the Hyperlane protocol on Starknet."
-version = "0.1.0"
+version = "0.0.6"
 edition = "2023_11"
 cairo-version = "2.6.3"
 

--- a/contracts/src/contracts/isms/multisig/validator_announce.cairo
+++ b/contracts/src/contracts/isms/multisig/validator_announce.cairo
@@ -126,10 +126,12 @@ pub mod validator_announce {
                     Option::None(_) => { break (); }
                 }
             };
-            let hash = compute_keccak(
-                array![ByteData { value: domain_hash.into(), is_address: false }]
-                    .concat(@byte_data_storage_location)
-                    .span()
+            let hash = reverse_endianness(
+                compute_keccak(
+                    array![ByteData { value: domain_hash.into(), is_address: false }]
+                        .concat(@byte_data_storage_location)
+                        .span()
+                )
             );
             to_eth_signature(hash)
         }
@@ -153,7 +155,7 @@ pub mod validator_announce {
             ByteData { value: mailboxclient_address.try_into().unwrap(), is_address: true },
             ByteData { value: HYPERLANE_ANNOUNCEMENT.into(), is_address: false }
         ];
-        compute_keccak(input.span())
+        reverse_endianness(compute_keccak(input.span()))
     }
 
 

--- a/contracts/src/contracts/mocks/mock_validator_announce.cairo
+++ b/contracts/src/contracts/mocks/mock_validator_announce.cairo
@@ -131,10 +131,12 @@ pub mod mock_validator_announce {
                     Option::None(_) => { break (); }
                 }
             };
-            let hash = compute_keccak(
-                array![ByteData { value: domain_hash, is_address: false }]
-                    .concat(@byte_data_storage_location)
-                    .span()
+            let hash = reverse_endianness(
+                compute_keccak(
+                    array![ByteData { value: domain_hash, is_address: false }]
+                        .concat(@byte_data_storage_location)
+                        .span()
+                )
             );
             to_eth_signature(hash)
         }
@@ -156,7 +158,7 @@ pub mod mock_validator_announce {
             ByteData { value: felt_address.into(), is_address: true },
             ByteData { value: HYPERLANE_ANNOUNCEMENT.into(), is_address: false }
         ];
-        compute_keccak(input.span())
+        reverse_endianness(compute_keccak(input.span()))
     }
 
 

--- a/contracts/src/tests/test_validator_announce.cairo
+++ b/contracts/src/tests/test_validator_announce.cairo
@@ -9,7 +9,6 @@ use starknet::{ContractAddress, contract_address_const, EthAddress};
 pub const TEST_STARKNET_DOMAIN: u32 = 23448594;
 
 #[test]
-#[ignore]
 fn test_digest_computation() {
     let mailbox_address = contract_address_const::<
         0x007a9a2e1663480b3845df0d714e8caa49f9241e13a826a678da3f366e546f2a
@@ -24,15 +23,11 @@ fn test_digest_computation() {
     ];
 
     let mut u256_storage_location: Array<u256> = array![];
-    let mut u128_storage_location: Array<u128> = array![];
 
     loop {
         match _storage_location.pop_front() {
             Option::Some(storage) => {
-                let u256_storage: u256 = storage.into();
                 u256_storage_location.append(storage.into());
-                u128_storage_location.append(u256_storage.high);
-                u128_storage_location.append(u256_storage.low);
             },
             Option::None(()) => { break (); },
         }

--- a/contracts/src/tests/test_validator_announce.cairo
+++ b/contracts/src/tests/test_validator_announce.cairo
@@ -6,36 +6,34 @@ use hyperlane_starknet::interfaces::{
 };
 use hyperlane_starknet::tests::setup::setup_mock_validator_announce;
 use starknet::{ContractAddress, contract_address_const, EthAddress};
-pub const TEST_STARKNET_DOMAIN: u32 = 23448594;
+pub const TEST_STARKNET_DOMAIN: u32 = 23448593;
 
 #[test]
 fn test_digest_computation() {
     let mailbox_address = contract_address_const::<
-        0x007a9a2e1663480b3845df0d714e8caa49f9241e13a826a678da3f366e546f2a
+        0x0228c4f640b613dba2107cabf930564bbdb1b4e2d283ba1843b91e6327f09f8e
     >();
 
     let va = setup_mock_validator_announce(mailbox_address, TEST_STARKNET_DOMAIN);
 
     let mut _storage_location: Array<felt252> = array![
         180946006308525359965345158532346553211983108462325076142963585023296502126,
-        90954189295124463684969781689350429239725285131197301894846683156275290468,
-        437702665339219319625098735984930420
+        90954189295124463684969781689350429239725285131197301894846683156275291225,
+        276191619276790668637754154763775604
     ];
 
     let mut u256_storage_location: Array<u256> = array![];
 
     loop {
         match _storage_location.pop_front() {
-            Option::Some(storage) => {
-                u256_storage_location.append(storage.into());
-            },
+            Option::Some(storage) => { u256_storage_location.append(storage.into()); },
             Option::None(()) => { break (); },
         }
     };
     let digest = va.get_announcement_digest(u256_storage_location);
 
     assert(
-        digest == 40337292979712068912728133078015055981594797182684375963274381097875032981584,
+        digest == 68490098148397702232337918459455233145663417151157276422147736490102791983827,
         'Wrong digest'
     );
 }

--- a/contracts/src/tests/test_validator_announce.cairo
+++ b/contracts/src/tests/test_validator_announce.cairo
@@ -16,6 +16,7 @@ fn test_digest_computation() {
 
     let va = setup_mock_validator_announce(mailbox_address, TEST_STARKNET_DOMAIN);
 
+    // file:///var/folders/kr/z3l_6qyn3znb6gbnddtvgsn40000gn/T/.tmpdY51LU/checkpoint
     let mut _storage_location: Array<felt252> = array![
         180946006308525359965345158532346553211983108462325076142963585023296502126,
         90954189295124463684969781689350429239725285131197301894846683156275291225,
@@ -32,6 +33,7 @@ fn test_digest_computation() {
     };
     let digest = va.get_announcement_digest(u256_storage_location);
 
+    // digest printed in an e2e local test of the hyperlane validator
     assert(
         digest == 68490098148397702232337918459455233145663417151157276422147736490102791983827,
         'Wrong digest'


### PR DESCRIPTION
## Changes
- Apply a `reverse_endianness` operation on each hash to match other implementations
- Fix test to match an e2e local test