### PR TITLE
feat: Implementing additional routing ISM functions

### DIFF
--- a/contracts/src/contracts/client/mailboxclient.cairo
+++ b/contracts/src/contracts/client/mailboxclient.cairo
@@ -103,7 +103,7 @@ mod mailboxclient {
             mailbox.delivered(_id)
         }
 
-        fn get_mailbox(self: @ContractState) -> ContractAddress {
+        fn mailbox(self: @ContractState) -> ContractAddress {
             self.mailbox.read()
         }
 

--- a/contracts/src/contracts/client/mailboxclient.cairo
+++ b/contracts/src/contracts/client/mailboxclient.cairo
@@ -103,6 +103,10 @@ mod mailboxclient {
             mailbox.delivered(_id)
         }
 
+        fn get_mailbox(self: @ContractState) -> ContractAddress {
+            self.mailbox.read()
+        }
+
         fn _dispatch(
             self: @ContractState,
             _destination_domain: u32,

--- a/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
+++ b/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
@@ -1,0 +1,186 @@
+#[starknet::contract]
+pub mod default_fallback_routing_ism {
+    use alexandria_bytes::Bytes;
+    use core::panic_with_felt252;
+    use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait};
+    use hyperlane_starknet::interfaces::{
+        IDomainRoutingIsm, IRoutingIsm, IInterchainSecurityModule, ModuleType,
+        IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
+        IMailboxClientDispatcher, IMailboxClientDispatcherTrait, IMailboxDispatcher,
+        IMailboxDispatcherTrait
+    };
+
+    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
+
+    use starknet::{ContractAddress, contract_address_const};
+
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+    #[abi(embed_v0)]
+    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
+
+    type Domain = u32;
+    type Index = u32;
+    #[storage]
+    struct Storage {
+        modules: LegacyMap<Domain, ContractAddress>,
+        domains: LegacyMap<Domain, Domain>,
+        mailbox_client: ContractAddress,
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        upgradeable: UpgradeableComponent::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        UpgradeableEvent: UpgradeableComponent::Event,
+    }
+
+    mod Errors {
+        pub const LENGTH_MISMATCH: felt252 = 'Length mismatch';
+        pub const ORIGIN_NOT_FOUND: felt252 = 'Origin not found';
+        pub const MODULE_CANNOT_BE_ZERO: felt252 = 'Module cannot be zero';
+        pub const DOMAIN_NOT_FOUND: felt252 = 'Domain not found';
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState, _owner: ContractAddress, _mailbox_client: ContractAddress
+    ) {
+        self.ownable.initializer(_owner);
+        self.mailbox_client.write(_mailbox_client);
+    }
+
+    #[abi(embed_v0)]
+    impl IDomainRoutingIsmImpl of IDomainRoutingIsm<ContractState> {
+        fn initialize(
+            ref self: ContractState, _domains: Span<u32>, _modules: Span<ContractAddress>
+        ) {
+            self.ownable.assert_only_owner();
+            assert(_domains.len() == _modules.len(), Errors::LENGTH_MISMATCH);
+            let mut cur_idx = 0;
+            loop {
+                if (cur_idx == _domains.len()) {
+                    break ();
+                }
+                _set(ref self, *_domains.at(cur_idx), *_modules.at(cur_idx));
+                cur_idx += 1;
+            }
+        }
+
+        fn set(ref self: ContractState, _domain: u32, _module: ContractAddress) {
+            self.ownable.assert_only_owner();
+            assert(_module != contract_address_const::<0>(), Errors::MODULE_CANNOT_BE_ZERO);
+            _set(ref self, _domain, _module);
+        }
+
+        fn remove(ref self: ContractState, _domain: u32) {
+            self.ownable.assert_only_owner();
+            _remove(ref self, _domain);
+        }
+
+        fn domains(self: @ContractState) -> Span<u32> {
+            let mut current_domain = self.domains.read(0);
+            let mut domains = array![];
+            loop {
+                let next_domain = self.domains.read(current_domain);
+                if next_domain == 0 {
+                    break ();
+                }
+                domains.append(current_domain);
+                current_domain = next_domain;
+            };
+            domains.span()
+        }
+
+        fn module(self: @ContractState, _origin: u32) -> ContractAddress {
+            let module = self.modules.read(_origin);
+            if (module == contract_address_const::<0>()) {
+                module
+            } else {
+                let mailbox_client_dispatcher = IMailboxClientDispatcher {
+                    contract_address: self.mailbox_client.read()
+                };
+                let mailbox_address = mailbox_client_dispatcher.get_mailbox();
+                IMailboxDispatcher { contract_address: mailbox_address }.get_default_ism()
+            }
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl IRoutingIsmImpl of IRoutingIsm<ContractState> {
+        fn route(self: @ContractState, _message: Message) -> ContractAddress {
+            self.modules.read(_message.origin)
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl IInterchainSecurityModuleImpl of IInterchainSecurityModule<ContractState> {
+        fn module_type(self: @ContractState) -> ModuleType {
+            ModuleType::ROUTING(starknet::get_contract_address())
+        }
+
+        fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
+            let ism_address = self.route(_message.clone());
+            let ism_dispatcher = IInterchainSecurityModuleDispatcher {
+                contract_address: ism_address
+            };
+            ism_dispatcher.verify(_metadata, _message)
+        }
+    }
+
+    fn find_last_domain(self: @ContractState) -> u32 {
+        let mut current_domain = self.domains.read(0);
+        loop {
+            let next_domain = self.domains.read(current_domain);
+            if next_domain == 0 {
+                break current_domain;
+            }
+            current_domain = next_domain;
+        }
+    }
+
+    fn find_domain_index(self: @ContractState, _domain: u32) -> Option<u32> {
+        let mut current_domain = 0;
+        loop {
+            let next_domain = self.domains.read(current_domain);
+            if next_domain == _domain {
+                break Option::Some(current_domain);
+            } else if next_domain == 0 {
+                break Option::None(());
+            }
+            current_domain = next_domain;
+        }
+    }
+
+    fn _remove(ref self: ContractState, _domain: u32) {
+        let domain_index = match find_domain_index(@self, _domain) {
+            Option::Some(index) => index,
+            Option::None(()) => {
+                panic_with_felt252(Errors::DOMAIN_NOT_FOUND);
+                0
+            }
+        };
+        let next_domain = self.domains.read(_domain);
+        self.domains.write(domain_index, next_domain);
+    }
+
+    fn _set(ref self: ContractState, _domain: u32, _module: ContractAddress) {
+        match find_domain_index(@self, _domain) {
+            Option::Some(_) => {},
+            Option::None(()) => {
+                let latest_domain = find_last_domain(@self);
+                self.domains.write(latest_domain, _domain);
+            }
+        }
+        self.modules.write(_domain, _module);
+    }
+}

--- a/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
+++ b/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
@@ -46,7 +46,6 @@ pub mod default_fallback_routing_ism {
 
     mod Errors {
         pub const LENGTH_MISMATCH: felt252 = 'Length mismatch';
-        pub const ORIGIN_NOT_FOUND: felt252 = 'Origin not found';
         pub const MODULE_CANNOT_BE_ZERO: felt252 = 'Module cannot be zero';
         pub const DOMAIN_NOT_FOUND: felt252 = 'Domain not found';
     }
@@ -71,6 +70,11 @@ pub mod default_fallback_routing_ism {
                 if (cur_idx == _domains.len()) {
                     break ();
                 }
+                assert(
+                    *_modules.at(cur_idx) != contract_address_const::<0>(),
+                    Errors::MODULE_CANNOT_BE_ZERO
+                );
+                let test: felt252 = (*_modules.at(cur_idx)).try_into().unwrap();
                 _set(ref self, *_domains.at(cur_idx), *_modules.at(cur_idx));
                 cur_idx += 1;
             }
@@ -93,6 +97,7 @@ pub mod default_fallback_routing_ism {
             loop {
                 let next_domain = self.domains.read(current_domain);
                 if next_domain == 0 {
+                    domains.append(current_domain);
                     break ();
                 }
                 domains.append(current_domain);
@@ -103,7 +108,7 @@ pub mod default_fallback_routing_ism {
 
         fn module(self: @ContractState, _origin: u32) -> ContractAddress {
             let module = self.modules.read(_origin);
-            if (module == contract_address_const::<0>()) {
+            if (module != contract_address_const::<0>()) {
                 module
             } else {
                 let mailbox_client_dispatcher = IMailboxClientDispatcher {

--- a/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
+++ b/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
@@ -181,7 +181,7 @@ pub mod default_fallback_routing_ism {
     fn _set(ref self: ContractState, _domain: u32, _module: ContractAddress) {
         match find_domain_index(@self, _domain) {
             Option::Some(_) => {},
-            Option::None(()) => {
+            Option::None => {
                 let latest_domain = find_last_domain(@self);
                 self.domains.write(latest_domain, _domain);
             }

--- a/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
+++ b/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
@@ -169,7 +169,7 @@ pub mod default_fallback_routing_ism {
     fn _remove(ref self: ContractState, _domain: u32) {
         let domain_index = match find_domain_index(@self, _domain) {
             Option::Some(index) => index,
-            Option::None(()) => {
+            Option::None => {
                 panic_with_felt252(Errors::DOMAIN_NOT_FOUND);
                 0
             }

--- a/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
+++ b/contracts/src/contracts/isms/routing/default_fallback_routing_ism.cairo
@@ -114,7 +114,7 @@ pub mod default_fallback_routing_ism {
                 let mailbox_client_dispatcher = IMailboxClientDispatcher {
                     contract_address: self.mailbox_client.read()
                 };
-                let mailbox_address = mailbox_client_dispatcher.get_mailbox();
+                let mailbox_address = mailbox_client_dispatcher.mailbox();
                 IMailboxDispatcher { contract_address: mailbox_address }.get_default_ism()
             }
         }

--- a/contracts/src/contracts/isms/routing/domain_routing_ism.cairo
+++ b/contracts/src/contracts/isms/routing/domain_routing_ism.cairo
@@ -65,6 +65,10 @@ pub mod domain_routing_ism {
                 if (cur_idx == _domains.len()) {
                     break ();
                 }
+                assert(
+                    *_modules.at(cur_idx) != contract_address_const::<0>(),
+                    Errors::MODULE_CANNOT_BE_ZERO
+                );
                 _set(ref self, *_domains.at(cur_idx), *_modules.at(cur_idx));
                 cur_idx += 1;
             }
@@ -87,6 +91,7 @@ pub mod domain_routing_ism {
             loop {
                 let next_domain = self.domains.read(current_domain);
                 if next_domain == 0 {
+                    domains.append(current_domain);
                     break ();
                 }
                 domains.append(current_domain);

--- a/contracts/src/interfaces.cairo
+++ b/contracts/src/interfaces.cairo
@@ -167,7 +167,7 @@ pub trait IMailboxClient<TContractState> {
 
     fn _is_delivered(self: @TContractState, _id: u256) -> bool;
 
-    fn get_mailbox(self: @TContractState) -> ContractAddress;
+    fn mailbox(self: @TContractState) -> ContractAddress;
 
     fn _dispatch(
         self: @TContractState,

--- a/contracts/src/interfaces.cairo
+++ b/contracts/src/interfaces.cairo
@@ -167,6 +167,8 @@ pub trait IMailboxClient<TContractState> {
 
     fn _is_delivered(self: @TContractState, _id: u256) -> bool;
 
+    fn get_mailbox(self: @TContractState) -> ContractAddress;
+
     fn _dispatch(
         self: @TContractState,
         _destination_domain: u32,

--- a/contracts/src/interfaces.cairo
+++ b/contracts/src/interfaces.cairo
@@ -242,8 +242,6 @@ pub trait IDomainRoutingIsm<TContractState> {
     fn domains(self: @TContractState) -> Span<u32>;
 
     fn module(self: @TContractState, _origin: u32) -> ContractAddress;
-
-    fn route(self: @TContractState, _message: Message) -> ContractAddress;
 }
 
 
@@ -341,4 +339,10 @@ pub trait IProtocolFee<TContractState> {
     fn set_beneficiary(ref self: TContractState, _beneficiary: ContractAddress);
 
     fn collect_protocol_fees(ref self: TContractState);
+}
+
+
+#[starknet::interface]
+pub trait IRoutingIsm<TContractState> {
+    fn route(self: @TContractState, _message: Message) -> ContractAddress;
 }

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -65,4 +65,8 @@ mod tests {
     pub mod hooks {
         pub mod test_protocol_fee;
     }
+    pub mod routing {
+        pub mod test_default_fallback_routing_ism;
+        pub mod test_domain_routing_ism;
+    }
 }

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -39,6 +39,7 @@ mod contracts {
             pub mod validator_announce;
         }
         pub mod routing {
+            pub mod default_fallback_routing_ism;
             pub mod domain_routing_ism;
         }
         pub mod aggregation {

--- a/contracts/src/tests/routing/test_default_fallback_routing_ism.cairo
+++ b/contracts/src/tests/routing/test_default_fallback_routing_ism.cairo
@@ -1,0 +1,311 @@
+use alexandria_bytes::{Bytes, BytesTrait};
+use hyperlane_starknet::contracts::libs::message::{Message, HYPERLANE_VERSION};
+use hyperlane_starknet::interfaces::{
+    ModuleType, IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
+    IRoutingIsmDispatcher, IRoutingIsmDispatcherTrait, IDomainRoutingIsmDispatcher,
+    IDomainRoutingIsmDispatcherTrait, IValidatorConfigurationDispatcher,
+    IValidatorConfigurationDispatcherTrait, IMailboxClientDispatcher, IMailboxClientDispatcherTrait,
+    IMailboxDispatcher, IMailboxDispatcherTrait
+};
+use hyperlane_starknet::tests::setup::{
+    OWNER, setup_default_fallback_routing_ism, build_messageid_metadata, LOCAL_DOMAIN,
+    DESTINATION_DOMAIN, RECIPIENT_ADDRESS, setup_messageid_multisig_ism, get_message_and_signature,
+    setup_mailbox_client
+};
+use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
+use snforge_std::{start_prank, CheatTarget, stop_prank, ContractClassTrait, declare};
+use starknet::{ContractAddress, contract_address_const};
+
+#[test]
+fn test_initialize() {
+    let _domains: Array<u32> = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    assert(fallback_routing_ism.domains() == _domains.span(), 'wrong domains init');
+    let mut cur_idx = 0;
+    loop {
+        if (cur_idx == _domains.len()) {
+            break ();
+        }
+        assert_eq!(*_modules.at(cur_idx), fallback_routing_ism.module(*_domains.at(cur_idx)));
+        cur_idx += 1;
+    }
+}
+
+
+#[test]
+fn get_default_module() {
+    let mailbox_client = setup_mailbox_client();
+    let default_fallback_routing_ism = declare("default_fallback_routing_ism").unwrap();
+    let (default_fallback_routing_ism_addr, _) = default_fallback_routing_ism
+        .deploy(@array![OWNER().into(), mailbox_client.contract_address.into()])
+        .unwrap();
+    let test_address = contract_address_const::<0x1331341>();
+    let dispatcher = IDomainRoutingIsmDispatcher {
+        contract_address: default_fallback_routing_ism_addr
+    };
+    let mailboxclient_dispatcher = IMailboxClientDispatcher {
+        contract_address: mailbox_client.contract_address
+    };
+    let mailbox = IMailboxDispatcher { contract_address: mailboxclient_dispatcher.get_mailbox() };
+    let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    mailbox.set_default_ism(test_address);
+    assert_eq!(dispatcher.module(1234), test_address);
+}
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn test_initialize_fails_if_caller_not_owner() {
+    let (_, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    let _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    fallback_routing_ism.initialize(_domains.span(), _modules.span())
+}
+
+#[test]
+#[should_panic(expected: ('Module cannot be zero',))]
+fn test_initialize_fails_if_module_is_zero() {
+    let (_, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    let _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0>()
+    ];
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span())
+}
+
+#[test]
+#[should_panic(expected: ('Length mismatch',))]
+fn test_initialize_fails_if_length_mismatch() {
+    let _domains = array![12345, 1123322, 312441, 131321];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+}
+
+
+#[test]
+fn test_remove_domain() {
+    let mut _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    fallback_routing_ism.remove(12345);
+    _domains.pop_front();
+    assert(_domains.span() == fallback_routing_ism.domains(), 'wrong domain del');
+}
+
+
+#[test]
+#[should_panic(expected: ('Domain not found',))]
+fn test_remove_domain_fails_if_domain_not_found() {
+    let _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    fallback_routing_ism.remove(1);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn test_remove_domain_fails_if_caller_not_owner() {
+    let _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    fallback_routing_ism.remove(12345);
+}
+
+
+#[test]
+fn test_set_domain_and_module() {
+    let mut _domains = array![12345, 1123322, 312441];
+    let mut _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    let new_domain = 111111;
+    let new_module = contract_address_const::<0x2134242342342>();
+    fallback_routing_ism.set(new_domain, new_module);
+    _domains.append(new_domain);
+    _modules.append(new_module);
+    assert(_domains.span() == fallback_routing_ism.domains(), 'wrong domain add');
+    let mut cur_idx = 0;
+    loop {
+        if (cur_idx == _domains.len()) {
+            break ();
+        }
+        assert_eq!(*_modules.at(cur_idx), fallback_routing_ism.module(*_domains.at(cur_idx)));
+        cur_idx += 1;
+    }
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn test_set_domain_and_module_fails_if_caller_is_not_owner() {
+    let mut _domains = array![12345, 1123322, 312441];
+    let mut _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    let new_domain = 111111;
+    let new_module = contract_address_const::<0x2134242342342>();
+    fallback_routing_ism.set(new_domain, new_module);
+}
+
+
+#[test]
+fn test_route_ism() {
+    let mut message = Message {
+        version: 3_u8,
+        nonce: 0_u32,
+        origin: 12345,
+        sender: 'SENDER'.try_into().unwrap(),
+        destination: 0_u32,
+        recipient: 'RECIPIENT'.try_into().unwrap(),
+        body: BytesTrait::new_empty(),
+    };
+    let mut _domains = array![12345, 1123322, 312441];
+    let mut _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, ism, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    assert_eq!(ism.route(message), *_modules.at(0));
+    message =
+        Message {
+            version: 3_u8,
+            nonce: 0_u32,
+            origin: 1123322,
+            sender: 'SENDER'.try_into().unwrap(),
+            destination: 0_u32,
+            recipient: 'RECIPIENT'.try_into().unwrap(),
+            body: BytesTrait::new_empty(),
+        };
+    assert_eq!(ism.route(message), *_modules.at(1));
+    message =
+        Message {
+            version: 3_u8,
+            nonce: 0_u32,
+            origin: 312441,
+            sender: 'SENDER'.try_into().unwrap(),
+            destination: 0_u32,
+            recipient: 'RECIPIENT'.try_into().unwrap(),
+            body: BytesTrait::new_empty(),
+        };
+    assert_eq!(ism.route(message), *_modules.at(2));
+    message =
+        Message {
+            version: 3_u8,
+            nonce: 0_u32,
+            origin: 1,
+            sender: 'SENDER'.try_into().unwrap(),
+            destination: 0_u32,
+            recipient: 'RECIPIENT'.try_into().unwrap(),
+            body: BytesTrait::new_empty(),
+        };
+    assert_eq!(ism.route(message), contract_address_const::<0>());
+}
+
+
+#[test]
+fn test_module_type() {
+    let (ism, _, _) = setup_default_fallback_routing_ism();
+    assert_eq!(ism.module_type(), ModuleType::ROUTING(ism.contract_address));
+}
+
+// for this test, we will reuse existing tests
+#[test]
+fn test_verify() {
+    // ISM MESSAGE AND METADATA CONFIGURATION
+    let array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
+    let message_body = BytesTrait::new(42, array);
+    let message = Message {
+        version: HYPERLANE_VERSION,
+        nonce: 0,
+        origin: LOCAL_DOMAIN,
+        sender: OWNER(),
+        destination: DESTINATION_DOMAIN,
+        recipient: RECIPIENT_ADDRESS(),
+        body: message_body.clone()
+    };
+    let (messageid, messageid_validator_configuration) = setup_messageid_multisig_ism();
+    let (_, validators_address, _) = get_message_and_signature();
+    let origin_merkle_tree: u256 = 'origin_merkle_tree_hook'.try_into().unwrap();
+    let root: u256 = 'root'.try_into().unwrap();
+    let index = 1;
+    let metadata = build_messageid_metadata(origin_merkle_tree, root, index);
+
+    // ISM CONFIGURATION
+    let ownable = IOwnableDispatcher {
+        contract_address: messageid_validator_configuration.contract_address
+    };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    messageid_validator_configuration.set_validators(validators_address.span());
+    messageid_validator_configuration.set_threshold(4);
+
+    // ROUTING TESTING
+    let mut _domains = array![LOCAL_DOMAIN, 1123322, 312441];
+    let mut _modules: Array<ContractAddress> = array![
+        messageid.contract_address,
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (ism, _, fallback_routing_ism) = setup_default_fallback_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    assert_eq!(ism.verify(metadata, message), true);
+}

--- a/contracts/src/tests/routing/test_default_fallback_routing_ism.cairo
+++ b/contracts/src/tests/routing/test_default_fallback_routing_ism.cairo
@@ -54,7 +54,7 @@ fn get_default_module() {
     let mailboxclient_dispatcher = IMailboxClientDispatcher {
         contract_address: mailbox_client.contract_address
     };
-    let mailbox = IMailboxDispatcher { contract_address: mailboxclient_dispatcher.get_mailbox() };
+    let mailbox = IMailboxDispatcher { contract_address: mailboxclient_dispatcher.mailbox() };
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     mailbox.set_default_ism(test_address);
@@ -117,7 +117,7 @@ fn test_remove_domain() {
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     fallback_routing_ism.initialize(_domains.span(), _modules.span());
     fallback_routing_ism.remove(12345);
-    _domains.pop_front();
+    _domains.pop_front().unwrap();
     assert(_domains.span() == fallback_routing_ism.domains(), 'wrong domain del');
 }
 

--- a/contracts/src/tests/routing/test_domain_routing_ism.cairo
+++ b/contracts/src/tests/routing/test_domain_routing_ism.cairo
@@ -1,0 +1,297 @@
+use alexandria_bytes::{Bytes, BytesTrait};
+use hyperlane_starknet::contracts::libs::message::{Message, HYPERLANE_VERSION};
+use hyperlane_starknet::interfaces::{
+    ModuleType, IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
+    IRoutingIsmDispatcher, IRoutingIsmDispatcherTrait, IDomainRoutingIsmDispatcher,
+    IDomainRoutingIsmDispatcherTrait, IValidatorConfigurationDispatcher,
+    IValidatorConfigurationDispatcherTrait, IMailboxClientDispatcher, IMailboxClientDispatcherTrait,
+    IMailboxDispatcher, IMailboxDispatcherTrait
+};
+use hyperlane_starknet::tests::setup::{
+    OWNER, setup_domain_routing_ism, build_messageid_metadata, LOCAL_DOMAIN, DESTINATION_DOMAIN,
+    RECIPIENT_ADDRESS, setup_messageid_multisig_ism, get_message_and_signature, setup_mailbox_client
+};
+use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
+use snforge_std::{start_prank, CheatTarget, stop_prank, ContractClassTrait, declare};
+use starknet::{ContractAddress, contract_address_const};
+
+#[test]
+fn test_initialize() {
+    let _domains: Array<u32> = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    assert(fallback_routing_ism.domains() == _domains.span(), 'wrong domains init');
+    let mut cur_idx = 0;
+    loop {
+        if (cur_idx == _domains.len()) {
+            break ();
+        }
+        assert_eq!(*_modules.at(cur_idx), fallback_routing_ism.module(*_domains.at(cur_idx)));
+        cur_idx += 1;
+    }
+}
+
+
+#[test]
+#[should_panic(expected: ('Origin not found',))]
+fn get_module_fails_if_origin_not_found() {
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    fallback_routing_ism.module(1233);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn test_initialize_fails_if_caller_not_owner() {
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    let _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    fallback_routing_ism.initialize(_domains.span(), _modules.span())
+}
+
+#[test]
+#[should_panic(expected: ('Module cannot be zero',))]
+fn test_initialize_fails_if_module_is_zero() {
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    let _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0>()
+    ];
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span())
+}
+
+#[test]
+#[should_panic(expected: ('Length mismatch',))]
+fn test_initialize_fails_if_length_mismatch() {
+    let _domains = array![12345, 1123322, 312441, 131321];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+}
+
+
+#[test]
+fn test_remove_domain() {
+    let mut _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    fallback_routing_ism.remove(12345);
+    _domains.pop_front();
+    assert(_domains.span() == fallback_routing_ism.domains(), 'wrong domain del');
+}
+
+
+#[test]
+#[should_panic(expected: ('Domain not found',))]
+fn test_remove_domain_fails_if_domain_not_found() {
+    let _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    fallback_routing_ism.remove(1);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn test_remove_domain_fails_if_caller_not_owner() {
+    let _domains = array![12345, 1123322, 312441];
+    let _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    fallback_routing_ism.remove(12345);
+}
+
+
+#[test]
+fn test_set_domain_and_module() {
+    let mut _domains = array![12345, 1123322, 312441];
+    let mut _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    let new_domain = 111111;
+    let new_module = contract_address_const::<0x2134242342342>();
+    fallback_routing_ism.set(new_domain, new_module);
+    _domains.append(new_domain);
+    _modules.append(new_module);
+    assert(_domains.span() == fallback_routing_ism.domains(), 'wrong domain add');
+    let mut cur_idx = 0;
+    loop {
+        if (cur_idx == _domains.len()) {
+            break ();
+        }
+        assert_eq!(*_modules.at(cur_idx), fallback_routing_ism.module(*_domains.at(cur_idx)));
+        cur_idx += 1;
+    }
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn test_set_domain_and_module_fails_if_caller_is_not_owner() {
+    let mut _domains = array![12345, 1123322, 312441];
+    let mut _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, _, fallback_routing_ism) = setup_domain_routing_ism();
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    let new_domain = 111111;
+    let new_module = contract_address_const::<0x2134242342342>();
+    fallback_routing_ism.set(new_domain, new_module);
+}
+
+
+#[test]
+fn test_route_ism() {
+    let mut message = Message {
+        version: 3_u8,
+        nonce: 0_u32,
+        origin: 12345,
+        sender: 'SENDER'.try_into().unwrap(),
+        destination: 0_u32,
+        recipient: 'RECIPIENT'.try_into().unwrap(),
+        body: BytesTrait::new_empty(),
+    };
+    let mut _domains = array![12345, 1123322, 312441];
+    let mut _modules: Array<ContractAddress> = array![
+        contract_address_const::<0x111>(),
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (_, ism, fallback_routing_ism) = setup_domain_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    assert_eq!(ism.route(message), *_modules.at(0));
+    message =
+        Message {
+            version: 3_u8,
+            nonce: 0_u32,
+            origin: 1123322,
+            sender: 'SENDER'.try_into().unwrap(),
+            destination: 0_u32,
+            recipient: 'RECIPIENT'.try_into().unwrap(),
+            body: BytesTrait::new_empty(),
+        };
+    assert_eq!(ism.route(message), *_modules.at(1));
+    message =
+        Message {
+            version: 3_u8,
+            nonce: 0_u32,
+            origin: 312441,
+            sender: 'SENDER'.try_into().unwrap(),
+            destination: 0_u32,
+            recipient: 'RECIPIENT'.try_into().unwrap(),
+            body: BytesTrait::new_empty(),
+        };
+    assert_eq!(ism.route(message), *_modules.at(2));
+    message =
+        Message {
+            version: 3_u8,
+            nonce: 0_u32,
+            origin: 1,
+            sender: 'SENDER'.try_into().unwrap(),
+            destination: 0_u32,
+            recipient: 'RECIPIENT'.try_into().unwrap(),
+            body: BytesTrait::new_empty(),
+        };
+    assert_eq!(ism.route(message), contract_address_const::<0>());
+}
+
+
+#[test]
+fn test_module_type() {
+    let (ism, _, _) = setup_domain_routing_ism();
+    assert_eq!(ism.module_type(), ModuleType::ROUTING(ism.contract_address));
+}
+
+// for this test, we will reuse existing tests
+#[test]
+fn test_verify() {
+    // ISM MESSAGE AND METADATA CONFIGURATION
+    let array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
+    let message_body = BytesTrait::new(42, array);
+    let message = Message {
+        version: HYPERLANE_VERSION,
+        nonce: 0,
+        origin: LOCAL_DOMAIN,
+        sender: OWNER(),
+        destination: DESTINATION_DOMAIN,
+        recipient: RECIPIENT_ADDRESS(),
+        body: message_body.clone()
+    };
+    let (messageid, messageid_validator_configuration) = setup_messageid_multisig_ism();
+    let (_, validators_address, _) = get_message_and_signature();
+    let origin_merkle_tree: u256 = 'origin_merkle_tree_hook'.try_into().unwrap();
+    let root: u256 = 'root'.try_into().unwrap();
+    let index = 1;
+    let metadata = build_messageid_metadata(origin_merkle_tree, root, index);
+
+    // ISM CONFIGURATION
+    let ownable = IOwnableDispatcher {
+        contract_address: messageid_validator_configuration.contract_address
+    };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    messageid_validator_configuration.set_validators(validators_address.span());
+    messageid_validator_configuration.set_threshold(4);
+
+    // ROUTING TESTING
+    let mut _domains = array![LOCAL_DOMAIN, 1123322, 312441];
+    let mut _modules: Array<ContractAddress> = array![
+        messageid.contract_address,
+        contract_address_const::<0x222>(),
+        contract_address_const::<0x333>()
+    ];
+    let (ism, _, fallback_routing_ism) = setup_domain_routing_ism();
+    let ownable = IOwnableDispatcher { contract_address: fallback_routing_ism.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    fallback_routing_ism.initialize(_domains.span(), _modules.span());
+    assert_eq!(ism.verify(metadata, message), true);
+}

--- a/contracts/src/tests/routing/test_domain_routing_ism.cairo
+++ b/contracts/src/tests/routing/test_domain_routing_ism.cairo
@@ -103,7 +103,7 @@ fn test_remove_domain() {
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     fallback_routing_ism.initialize(_domains.span(), _modules.span());
     fallback_routing_ism.remove(12345);
-    _domains.pop_front();
+    _domains.pop_front().unwrap();
     assert(_domains.span() == fallback_routing_ism.domains(), 'wrong domain del');
 }
 

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -11,7 +11,9 @@ use hyperlane_starknet::interfaces::{
     IValidatorConfigurationDispatcher, IMerkleTreeHookDispatcher, IMerkleTreeHookDispatcherTrait,
     IAggregation, IPostDispatchHookDispatcher, IProtocolFeeDispatcher,
     IPostDispatchHookDispatcherTrait, IProtocolFeeDispatcherTrait, IMockValidatorAnnounceDispatcher,
-    ISpecifiesInterchainSecurityModuleDispatcher, ISpecifiesInterchainSecurityModuleDispatcherTrait,IRoutingIsmDispatcher, IRoutingIsmDispatcherTrait, IDomainRoutingIsmDispatcher, IDomainRoutingIsmDispatcherTrait
+    ISpecifiesInterchainSecurityModuleDispatcher, ISpecifiesInterchainSecurityModuleDispatcherTrait,
+    IRoutingIsmDispatcher, IRoutingIsmDispatcherTrait, IDomainRoutingIsmDispatcher,
+    IDomainRoutingIsmDispatcherTrait
 };
 use openzeppelin::account::utils::signature::EthSignature;
 use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
@@ -193,17 +195,31 @@ pub fn setup_mailbox_client() -> IMailboxClientDispatcher {
     IMailboxClientDispatcher { contract_address: mailboxclient_addr }
 }
 
-pub fn setup_default_fallback_routing_ism() -> (IInterchainSecurityModuleDispatcher, IRoutingIsmDispatcher, IDomainRoutingIsmDispatcher) {
+pub fn setup_default_fallback_routing_ism() -> (
+    IInterchainSecurityModuleDispatcher, IRoutingIsmDispatcher, IDomainRoutingIsmDispatcher
+) {
     let mailbox_client = setup_mailbox_client();
     let default_fallback_routing_ism = declare("default_fallback_routing_ism").unwrap();
-    let (default_fallback_routing_ism_addr, _) = default_fallback_routing_ism.deploy(@array![OWNER().into(),mailbox_client.contract_address.into()]).unwrap();
-    (IInterchainSecurityModuleDispatcher{contract_address: default_fallback_routing_ism_addr }, IRoutingIsmDispatcher{contract_address: default_fallback_routing_ism_addr }, IDomainRoutingIsmDispatcher{contract_address: default_fallback_routing_ism_addr })
+    let (default_fallback_routing_ism_addr, _) = default_fallback_routing_ism
+        .deploy(@array![OWNER().into(), mailbox_client.contract_address.into()])
+        .unwrap();
+    (
+        IInterchainSecurityModuleDispatcher { contract_address: default_fallback_routing_ism_addr },
+        IRoutingIsmDispatcher { contract_address: default_fallback_routing_ism_addr },
+        IDomainRoutingIsmDispatcher { contract_address: default_fallback_routing_ism_addr }
+    )
 }
 
-pub fn setup_domain_routing_ism() -> (IInterchainSecurityModuleDispatcher, IRoutingIsmDispatcher, IDomainRoutingIsmDispatcher) {
+pub fn setup_domain_routing_ism() -> (
+    IInterchainSecurityModuleDispatcher, IRoutingIsmDispatcher, IDomainRoutingIsmDispatcher
+) {
     let domain_routing_ism = declare("domain_routing_ism").unwrap();
     let (domain_routing_ism_addr, _) = domain_routing_ism.deploy(@array![OWNER().into()]).unwrap();
-    (IInterchainSecurityModuleDispatcher{contract_address: domain_routing_ism_addr }, IRoutingIsmDispatcher{contract_address: domain_routing_ism_addr }, IDomainRoutingIsmDispatcher{contract_address: domain_routing_ism_addr })
+    (
+        IInterchainSecurityModuleDispatcher { contract_address: domain_routing_ism_addr },
+        IRoutingIsmDispatcher { contract_address: domain_routing_ism_addr },
+        IDomainRoutingIsmDispatcher { contract_address: domain_routing_ism_addr }
+    )
 }
 
 pub fn setup_validator_announce() -> (IValidatorAnnounceDispatcher, EventSpy) {

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -11,7 +11,7 @@ use hyperlane_starknet::interfaces::{
     IValidatorConfigurationDispatcher, IMerkleTreeHookDispatcher, IMerkleTreeHookDispatcherTrait,
     IAggregation, IPostDispatchHookDispatcher, IProtocolFeeDispatcher,
     IPostDispatchHookDispatcherTrait, IProtocolFeeDispatcherTrait, IMockValidatorAnnounceDispatcher,
-    ISpecifiesInterchainSecurityModuleDispatcher, ISpecifiesInterchainSecurityModuleDispatcherTrait,
+    ISpecifiesInterchainSecurityModuleDispatcher, ISpecifiesInterchainSecurityModuleDispatcherTrait,IRoutingIsmDispatcher, IRoutingIsmDispatcherTrait, IDomainRoutingIsmDispatcher, IDomainRoutingIsmDispatcherTrait
 };
 use openzeppelin::account::utils::signature::EthSignature;
 use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
@@ -183,6 +183,7 @@ pub fn setup_merkleroot_multisig_ism() -> (
     )
 }
 
+
 pub fn setup_mailbox_client() -> IMailboxClientDispatcher {
     let (mailbox, _, _, _) = setup();
     let mailboxclient_class = declare("mailboxclient").unwrap();
@@ -190,6 +191,19 @@ pub fn setup_mailbox_client() -> IMailboxClientDispatcher {
         .deploy(@array![mailbox.contract_address.into(), OWNER().into()])
         .unwrap();
     IMailboxClientDispatcher { contract_address: mailboxclient_addr }
+}
+
+pub fn setup_default_fallback_routing_ism() -> (IInterchainSecurityModuleDispatcher, IRoutingIsmDispatcher, IDomainRoutingIsmDispatcher) {
+    let mailbox_client = setup_mailbox_client();
+    let default_fallback_routing_ism = declare("default_fallback_routing_ism").unwrap();
+    let (default_fallback_routing_ism_addr, _) = default_fallback_routing_ism.deploy(@array![OWNER().into(),mailbox_client.contract_address.into()]).unwrap();
+    (IInterchainSecurityModuleDispatcher{contract_address: default_fallback_routing_ism_addr }, IRoutingIsmDispatcher{contract_address: default_fallback_routing_ism_addr }, IDomainRoutingIsmDispatcher{contract_address: default_fallback_routing_ism_addr })
+}
+
+pub fn setup_domain_routing_ism() -> (IInterchainSecurityModuleDispatcher, IRoutingIsmDispatcher, IDomainRoutingIsmDispatcher) {
+    let domain_routing_ism = declare("domain_routing_ism").unwrap();
+    let (domain_routing_ism_addr, _) = domain_routing_ism.deploy(@array![OWNER().into()]).unwrap();
+    (IInterchainSecurityModuleDispatcher{contract_address: domain_routing_ism_addr }, IRoutingIsmDispatcher{contract_address: domain_routing_ism_addr }, IDomainRoutingIsmDispatcher{contract_address: domain_routing_ism_addr })
 }
 
 pub fn setup_validator_announce() -> (IValidatorAnnounceDispatcher, EventSpy) {

--- a/contracts/src/tests/test_validator_announce.cairo
+++ b/contracts/src/tests/test_validator_announce.cairo
@@ -16,7 +16,7 @@ pub const TEST_STARKNET_DOMAIN: u32 = 23448593;
 #[test]
 fn test_announce() {
     let (validator_announce, mut spy) = setup_validator_announce();
-    let validator_address: EthAddress = 0x77adfc80b36fdc16cdcfcc11be9ca3c647ef1c0e
+    let validator_address: EthAddress = 0xe289c75959a3e93953180b42b3a2a190a120719d
         .try_into()
         .unwrap();
     let mut _storage_location: Array<felt252> = array![
@@ -64,7 +64,7 @@ fn test_announce_fails_if_wrong_signer() {
 #[should_panic(expected: ('Announce already occured',))]
 fn test_announce_fails_if_replay() {
     let (validator_announce, _) = setup_validator_announce();
-    let validator_address: EthAddress = 0x77adfc80b36fdc16cdcfcc11be9ca3c647ef1c0e
+    let validator_address: EthAddress = 0xe289c75959a3e93953180b42b3a2a190a120719d
         .try_into()
         .unwrap();
     let mut storage_location: Array<felt252> = array![

--- a/contracts/src/tests/test_validator_announce.cairo
+++ b/contracts/src/tests/test_validator_announce.cairo
@@ -16,7 +16,7 @@ pub const TEST_STARKNET_DOMAIN: u32 = 23448593;
 #[test]
 fn test_announce() {
     let (validator_announce, mut spy) = setup_validator_announce();
-    let validator_address: EthAddress = 0xe289c75959a3e93953180b42b3a2a190a120719d
+    let validator_address: EthAddress = 0xc96bfb43ca7468df7226cf39e9fdf0e0c52e88a2
         .try_into()
         .unwrap();
     let mut _storage_location: Array<felt252> = array![
@@ -64,7 +64,7 @@ fn test_announce_fails_if_wrong_signer() {
 #[should_panic(expected: ('Announce already occured',))]
 fn test_announce_fails_if_replay() {
     let (validator_announce, _) = setup_validator_announce();
-    let validator_address: EthAddress = 0xe289c75959a3e93953180b42b3a2a190a120719d
+    let validator_address: EthAddress = 0xc96bfb43ca7468df7226cf39e9fdf0e0c52e88a2
         .try_into()
         .unwrap();
     let mut storage_location: Array<felt252> = array![


### PR DESCRIPTION
 **Resolves #27**
 
Domain Routing ISM: 

- [x] Add Routing ISM interface and associated function (route)
- [x]  Add ISM interface and associated functions (verify and module_type)
- [x] Add tests

Default Fallback Routing ISM: 

- [x] Define the contract
- [x] Change the module function
- [x] Add tests