### PR TITLE
Fix: message formatting

### DIFF
--- a/contracts/src/contracts/client/mailboxclient.cairo
+++ b/contracts/src/contracts/client/mailboxclient.cairo
@@ -47,6 +47,7 @@ mod mailboxclient {
     impl Upgradeable of IUpgradeable<ContractState> {
         /// Upgrades the contract to a new implementation.
         /// Callable only by the owner
+        /// 
         /// # Arguments
         ///
         /// * `new_class_hash` - The class hash of the new implementation.

--- a/contracts/src/contracts/client/mailboxclient_component.cairo
+++ b/contracts/src/contracts/client/mailboxclient_component.cairo
@@ -1,6 +1,6 @@
 #[starknet::component]
 pub mod MailboxclientComponent {
-    use alexandria_bytes::{Bytes, BytesTrait};
+    use alexandria_bytes::Bytes;
     use hyperlane_starknet::interfaces::{
         IMailboxClient, IMailboxDispatcher, IMailboxDispatcherTrait
     };
@@ -23,12 +23,24 @@ pub mod MailboxclientComponent {
         +HasComponent<TContractState>,
         impl Owner: OwnableComponent::HasComponent<TContractState>
     > of IMailboxClient<ComponentState<TContractState>> {
+        /// Sets the address of the application's custom hook.
+        /// Dev: callable only by the admin
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_hook` - The hook address to set 
         fn set_hook(ref self: ComponentState<TContractState>, _hook: ContractAddress) {
             let ownable_comp = get_dep_component!(@self, Owner);
             ownable_comp.assert_only_owner();
             self.hook.write(_hook);
         }
 
+        /// Sets the address of the application's custom interchain security module.
+        /// Dev: Callable only by the admin
+        /// 
+        /// # Arguments
+        /// 
+        /// * - '_module' - The address of the interchain security module contract.
         fn set_interchain_security_module(
             ref self: ComponentState<TContractState>, _module: ContractAddress
         ) {
@@ -37,14 +49,29 @@ pub mod MailboxclientComponent {
             self.interchain_security_module.write(_module);
         }
 
+        /// Retrieve the local domain of the mailbox associated to the maiblox client. 
+        /// 
+        /// # Returns
+        /// 
+        /// u32  - The local domain
         fn get_local_domain(self: @ComponentState<TContractState>) -> u32 {
             self.mailbox.read().get_local_domain()
         }
 
+        /// Retrieve the current hook set.
+        /// 
+        /// # Returns
+        /// 
+        /// ContractAddress  - The hook defined
         fn get_hook(self: @ComponentState<TContractState>) -> ContractAddress {
             self.hook.read()
         }
 
+        /// Retrieve the current interchain security module 
+        /// 
+        /// # Returns
+        /// 
+        /// ContractAddress  - The defined ISM
         fn get_interchain_security_module(
             self: @ComponentState<TContractState>
         ) -> ContractAddress {
@@ -52,6 +79,13 @@ pub mod MailboxclientComponent {
         }
 
 
+        /// Initialize the mailbox client configuration.
+        /// Dev: callable only by the admin
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_hook` the contract address associated to the hook to be defined
+        /// * - `_interchain_security_module`- The contract address associated to the ISM to be defined
         fn _MailboxClient_initialize(
             ref self: ComponentState<TContractState>,
             _hook: ContractAddress,
@@ -63,19 +97,55 @@ pub mod MailboxclientComponent {
             self.set_interchain_security_module(_interchain_security_module);
         }
 
+        /// Determine if a message associated to a given id is the mailbox's latest dispatched
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_id ` - The id to check
+        /// 
+        /// # Returns
+        /// 
+        /// boolean  - is it dispatched ?
         fn _is_latest_dispatched(self: @ComponentState<TContractState>, _id: u256) -> bool {
             self.mailbox.read().get_latest_dispatched_id() == _id
         }
 
+        /// Determine if a message associated to a given id is delivered
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_id ` - The id to check
+        /// 
+        /// # Returns
+        /// 
+        /// boolean  - is it delivered ?
         fn _is_delivered(self: @ComponentState<TContractState>, _id: u256) -> bool {
             self.mailbox.read().delivered(_id)
         }
 
+        /// Returns the mailbox contract associated to the mailbox client
+        /// 
+        /// # Returns
+        /// 
+        /// ContractAddress  - the mailbox address associated to the client
         fn mailbox(self: @ComponentState<TContractState>) -> ContractAddress {
             let mailbox: IMailboxDispatcher = self.mailbox.read();
             mailbox.contract_address
         }
 
+        /// Dispatches a message to the destination domain & recipient.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_destination_domain` Domain of destination chain
+        /// * - `_recipient` Address of recipient on destination chain
+        /// * - `_message_body` Bytes content of message body
+        /// * - `_hook_metadata` Metadata used by the post dispatch hook
+        /// * - `_hook` Custom hook to use instead of the default
+        /// 
+        /// # Returns 
+        /// 
+        /// u256 - The message ID inserted into the Mailbox's merkle tree
         fn _dispatch(
             self: @ComponentState<TContractState>,
             _destination_domain: u32,
@@ -90,6 +160,19 @@ pub mod MailboxclientComponent {
                 .dispatch(_destination_domain, _recipient, _message_body, _hook_metadata, _hook)
         }
 
+        /// Computes quote for dispatching a message to the destination domain & recipient.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_destination_domain` Domain of destination chain
+        /// * - `_recipient` Address of recipient on destination chain
+        /// * - `_message_body` Bytes content of message body
+        /// * - `_hook_metadata` Metadata used by the post dispatch hook
+        /// * - `_hook` Custom hook to use instead of the default
+        /// 
+        /// # Returns 
+        /// 
+        /// u256 - The payment required to dispatch the message
         fn quote_dispatch(
             self: @ComponentState<TContractState>,
             _destination_domain: u32,
@@ -113,6 +196,12 @@ pub mod MailboxclientComponent {
         +HasComponent<TContractState>,
         impl Owner: OwnableComponent::HasComponent<TContractState>
     > of InternalTrait<TContractState> {
+        /// Initialize the mailbox client configuration.
+        /// Dev: callable on constructor
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_mailbox` the contract address associated to the mailbox to be used
         fn initialize(ref self: ComponentState<TContractState>, _mailbox: ContractAddress) {
             let mailbox = IMailboxDispatcher { contract_address: _mailbox };
             self.mailbox.write(mailbox);

--- a/contracts/src/contracts/client/mailboxclient_component.cairo
+++ b/contracts/src/contracts/client/mailboxclient_component.cairo
@@ -55,7 +55,7 @@ pub mod MailboxclientComponent {
             self.interchain_security_module.write(_module);
         }
 
-        /// Retrieve the local domain of the mailbox associated to the maiblox client. 
+        /// Retrieves the local domain of the mailbox associated to the maiblox client. 
         /// 
         /// # Returns
         /// 
@@ -64,7 +64,7 @@ pub mod MailboxclientComponent {
             self.mailbox.read().get_local_domain()
         }
 
-        /// Retrieve the current hook set.
+        /// Retrieves the current hook set.
         /// 
         /// # Returns
         /// 
@@ -73,7 +73,7 @@ pub mod MailboxclientComponent {
             self.hook.read()
         }
 
-        /// Retrieve the current interchain security module 
+        /// Retrieves the current interchain security module 
         /// 
         /// # Returns
         /// 
@@ -85,13 +85,13 @@ pub mod MailboxclientComponent {
         }
 
 
-        /// Initialize the mailbox client configuration.
+        /// Initializes the mailbox client configuration.
         /// Dev: callable only by the admin
         /// 
         /// # Arguments
         /// 
-        /// * - `_hook` the contract address associated to the hook to be defined
-        /// * - `_interchain_security_module`- The contract address associated to the ISM to be defined
+        /// * - `_hook` the hook contract address to set
+        /// * - `_interchain_security_module`- the ISM contract address
         fn _MailboxClient_initialize(
             ref self: ComponentState<TContractState>,
             _hook: ContractAddress,
@@ -103,7 +103,7 @@ pub mod MailboxclientComponent {
             self.set_interchain_security_module(_interchain_security_module);
         }
 
-        /// Determine if a message associated to a given id is the mailbox's latest dispatched
+        /// Determines if a message associated to a given id is the mailbox's latest dispatched
         /// 
         /// # Arguments
         /// 
@@ -111,12 +111,12 @@ pub mod MailboxclientComponent {
         /// 
         /// # Returns
         /// 
-        /// boolean  - is it dispatched ?
+        /// boolean  - True if latest dispatched
         fn _is_latest_dispatched(self: @ComponentState<TContractState>, _id: u256) -> bool {
             self.mailbox.read().get_latest_dispatched_id() == _id
         }
 
-        /// Determine if a message associated to a given id is delivered
+        /// Determines if a message associated to a given id is delivered
         /// 
         /// # Arguments
         /// 
@@ -124,12 +124,12 @@ pub mod MailboxclientComponent {
         /// 
         /// # Returns
         /// 
-        /// boolean  - is it delivered ?
+        /// boolean  - True if delivered
         fn _is_delivered(self: @ComponentState<TContractState>, _id: u256) -> bool {
             self.mailbox.read().delivered(_id)
         }
 
-        /// Returns the mailbox contract associated to the mailbox client
+        /// Returns the mailbox contract address associated to the mailbox client
         /// 
         /// # Returns
         /// 
@@ -202,12 +202,12 @@ pub mod MailboxclientComponent {
         +HasComponent<TContractState>,
         impl Owner: OwnableComponent::HasComponent<TContractState>
     > of InternalTrait<TContractState> {
-        /// Initialize the mailbox client configuration.
+        /// Initializes the mailbox client configuration.
         /// Dev: callable on constructor
         /// 
         /// # Arguments
         /// 
-        /// * - `_mailbox` the contract address associated to the mailbox to be used
+        /// * - `_mailbox` - mailbox contract address
         fn initialize(ref self: ComponentState<TContractState>, _mailbox: ContractAddress) {
             let mailbox = IMailboxDispatcher { contract_address: _mailbox };
             self.mailbox.write(mailbox);

--- a/contracts/src/contracts/hooks/libs/standard_hook_metadata.cairo
+++ b/contracts/src/contracts/hooks/libs/standard_hook_metadata.cairo
@@ -33,7 +33,6 @@ pub mod standard_hook_metadata {
         /// # Arguments
         /// 
         /// * - `_metadata` - encoded standard hook metadata
-        /// * - `_default` - Default fallback value.
         /// 
         /// # Returns
         /// 

--- a/contracts/src/contracts/hooks/libs/standard_hook_metadata.cairo
+++ b/contracts/src/contracts/hooks/libs/standard_hook_metadata.cairo
@@ -9,6 +9,15 @@ pub mod standard_hook_metadata {
         refund_address: ContractAddress
     }
 
+
+ /// Format of metadata:
+ ///
+ /// [0:2] variant
+ /// [2:34] msg.value
+ /// [34:66] Gas limit for message (IGP)
+ /// [66:98] Refund address for message (IGP)
+ /// [98:] Custom metadata
+
     const VARIANT_OFFSET: u8 = 0;
     const MSG_VALUE_OFFSET: u8 = 2;
     const GAS_LIMIT_OFFSET: u8 = 34;
@@ -19,6 +28,17 @@ pub mod standard_hook_metadata {
 
     #[generate_trait]
     pub impl StandardHookMetadataImpl of StandardHookMetadata {
+
+        /// Returns the variant of the metadata.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded standard hook metadata
+        /// * - `_default` - Default fallback value.
+        /// 
+        /// # Returns
+        /// 
+        /// u16 -  variant of the metadata
         fn variant(_metadata: Bytes) -> u16 {
             if (_metadata.size() < VARIANT_OFFSET.into() + 2) {
                 return 0;
@@ -27,6 +47,16 @@ pub mod standard_hook_metadata {
             res
         }
 
+        /// Returns the specified value for the message.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded standard hook metadata
+        /// * - `_default` - Default fallback value.
+        /// 
+        /// # Returns
+        /// 
+        /// u256 -  Value for the message
         fn msg_value(_metadata: Bytes, _default: u256) -> u256 {
             if (_metadata.size() < MSG_VALUE_OFFSET.into() + 32) {
                 return _default;
@@ -35,6 +65,16 @@ pub mod standard_hook_metadata {
             res
         }
 
+        /// Returns the specified gas limit for the message.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded standard hook metadata
+        /// * - `_default` - Default fallback gas limit.
+        /// 
+        /// # Returns
+        /// 
+        /// u256 -  Gas limit for the message
         fn gas_limit(_metadata: Bytes, _default: u256) -> u256 {
             if (_metadata.size() < GAS_LIMIT_OFFSET.into() + 32) {
                 return _default;
@@ -43,6 +83,16 @@ pub mod standard_hook_metadata {
             res
         }
 
+        /// Returns the specified refund address for the message.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded standard hook metadata
+        /// * - `_default` - Default fallback refund address.
+        /// 
+        /// # Returns
+        /// 
+        /// ContractAddress -  Refund address for the message
         fn refund_address(_metadata: Bytes, _default: ContractAddress) -> ContractAddress {
             if (_metadata.size() < REFUND_ADDRESS_OFFSET.into() + 32) {
                 return _default;
@@ -50,7 +100,16 @@ pub mod standard_hook_metadata {
             let (_, res) = _metadata.read_address(REFUND_ADDRESS_OFFSET.into());
             res
         }
-
+        
+        ///Returns any custom metadata.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded standard hook metadata
+        /// 
+        /// # Returns
+        /// 
+        /// Bytes -  Custom metadata.
         fn get_custom_metadata(_metadata: Bytes) -> Bytes {
             if (_metadata.size().into() < MIN_METADATA_LENGTH) {
                 return BytesTrait::new_empty();

--- a/contracts/src/contracts/hooks/libs/standard_hook_metadata.cairo
+++ b/contracts/src/contracts/hooks/libs/standard_hook_metadata.cairo
@@ -10,13 +10,13 @@ pub mod standard_hook_metadata {
     }
 
 
- /// Format of metadata:
- ///
- /// [0:2] variant
- /// [2:34] msg.value
- /// [34:66] Gas limit for message (IGP)
- /// [66:98] Refund address for message (IGP)
- /// [98:] Custom metadata
+    /// Format of metadata:
+    ///
+    /// [0:2] variant
+    /// [2:34] msg.value
+    /// [34:66] Gas limit for message (IGP)
+    /// [66:98] Refund address for message (IGP)
+    /// [98:] Custom metadata
 
     const VARIANT_OFFSET: u8 = 0;
     const MSG_VALUE_OFFSET: u8 = 2;
@@ -28,7 +28,6 @@ pub mod standard_hook_metadata {
 
     #[generate_trait]
     pub impl StandardHookMetadataImpl of StandardHookMetadata {
-
         /// Returns the variant of the metadata.
         /// 
         /// # Arguments
@@ -100,7 +99,7 @@ pub mod standard_hook_metadata {
             let (_, res) = _metadata.read_address(REFUND_ADDRESS_OFFSET.into());
             res
         }
-        
+
         ///Returns any custom metadata.
         /// 
         /// # Arguments

--- a/contracts/src/contracts/hooks/merkle_tree_hook.cairo
+++ b/contracts/src/contracts/hooks/merkle_tree_hook.cairo
@@ -79,7 +79,7 @@ pub mod merkle_tree_hook {
         pub index: u32
     }
 
-    /// Constructor of the contract
+    /// Contract constructor
     /// 
     /// # Arguments
     ///
@@ -143,7 +143,7 @@ pub mod merkle_tree_hook {
         }
 
         /// Post action after a message is dispatched via the Mailbox
-        /// Dev: revert if invalid metadata variant
+        /// Dev: reverts if invalid metadata variant
         /// 
         /// # Arguments
         /// 
@@ -154,8 +154,8 @@ pub mod merkle_tree_hook {
             self._post_dispatch(_metadata, _message);
         }
 
-        ///  Compute the payment required by the postDispatch call
-        /// Dev: revert if invalid metadata variant
+        ///  Computes the payment required by the postDispatch call
+        /// Dev: reverts if invalid metadata variant
         /// 
         /// # Arguments
         /// 
@@ -187,7 +187,7 @@ pub mod merkle_tree_hook {
         /// 
         /// # Arguments
         /// 
-        ///* - `_node`-  Element to insert into tree
+        ///* - `_node`-  Element to insert into tree (see ByteData structure)
         fn _insert(ref self: ContractState, mut _node: ByteData) {
             let MAX_LEAVES: u128 = pow(2_u128, TREE_DEPTH.into()) - 1;
             assert(self.count.read().into() < MAX_LEAVES, Errors::MERKLE_TREE_FULL);

--- a/contracts/src/contracts/hooks/merkle_tree_hook.cairo
+++ b/contracts/src/contracts/hooks/merkle_tree_hook.cairo
@@ -21,13 +21,6 @@ pub mod merkle_tree_hook {
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
     use starknet::{ContractAddress, ClassHash};
 
-    #[derive(Serde, Drop)]
-    pub struct Tree {
-        pub branch: Array<ByteData>,
-        pub count: u256
-    }
-    type Index = usize;
-    pub const TREE_DEPTH: u32 = 32;
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
     component!(path: MailboxclientComponent, storage: mailboxclient, event: MailboxclientEvent);
@@ -37,6 +30,14 @@ pub mod merkle_tree_hook {
     impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
+    #[derive(Serde, Drop)]
+    pub struct Tree {
+        pub branch: Array<ByteData>,
+        pub count: u256
+    }
+
+    type Index = usize;
+    pub const TREE_DEPTH: u32 = 32;
 
     #[storage]
     struct Storage {
@@ -77,6 +78,12 @@ pub mod merkle_tree_hook {
         pub index: u32
     }
 
+    /// Constructor of the contract
+    /// 
+    /// # Arguments
+    ///
+    /// * `_mailbox` - The mailbox to be associated to the mailbox client
+    /// * `_owner` - The owner of the contract
     #[constructor]
     fn constructor(ref self: ContractState, _mailbox: ContractAddress, _owner: ContractAddress,) {
         self.mailboxclient.initialize(_mailbox);
@@ -87,6 +94,7 @@ pub mod merkle_tree_hook {
     impl Upgradeable of IUpgradeable<ContractState> {
         /// Upgrades the contract to a new implementation.
         /// Callable only by the owner
+        /// 
         /// # Arguments
         ///
         /// * `new_class_hash` - The class hash of the new implementation.
@@ -120,15 +128,42 @@ pub mod merkle_tree_hook {
         fn hook_type(self: @ContractState) -> Types {
             Types::MERKLE_TREE(())
         }
+        /// Returns whether the hook supports metadata
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - metadata
+        /// 
+        /// # Returns
+        /// 
+        /// boolean - whether the hook supports metadata
         fn supports_metadata(self: @ContractState, _metadata: Bytes) -> bool {
             _metadata.size() == 0 || StandardHookMetadata::variant(_metadata) == VARIANT.into()
         }
 
+        /// Post action after a message is dispatched via the Mailbox
+        /// Dev: revert if invalid metadata variant
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - the metadata required for the hook
+        /// * - `_message` - the message passed from the Mailbox.dispatch() call
         fn post_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) {
             assert(self.supports_metadata(_metadata.clone()), Errors::INVALID_METADATA_VARIANT);
             self._post_dispatch(_metadata, _message);
         }
 
+        ///  Compute the payment required by the postDispatch call
+        /// Dev: revert if invalid metadata variant
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - The metadata required for the hook
+        /// * - `_message` - the message passed from the Mailbox.dispatch() call
+        /// 
+        /// # Returns 
+        /// 
+        /// u256 - Quoted payment for the postDispatch call
         fn quote_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) -> u256 {
             assert(self.supports_metadata(_metadata.clone()), Errors::INVALID_METADATA_VARIANT);
             self._quote_dispatch(_metadata, _message)
@@ -145,6 +180,12 @@ pub mod merkle_tree_hook {
             self.emit(InsertedIntoTree { id, index });
         }
 
+        /// Inserts `_node` into merkle tree
+        /// Dev: Reverts if tree is full
+        /// 
+        /// # Arguments
+        /// 
+        ///* - `_node`-  Element to insert into tree
         fn _insert(ref self: ContractState, mut _node: ByteData) {
             let MAX_LEAVES: u128 = pow(2_u128, TREE_DEPTH.into()) - 1;
             assert(self.count.read().into() < MAX_LEAVES, Errors::MERKLE_TREE_FULL);
@@ -170,6 +211,16 @@ pub mod merkle_tree_hook {
                 cur_idx += 1;
             };
         }
+
+        /// Calculates and returns`_tree`'s current root given array of zero hashes
+        /// 
+        /// # Arguments
+        /// 
+        ///* - `_zeroes`- Array of zero hashes
+        /// 
+        /// # Returns
+        /// 
+        /// u256 - Calculated root of `_tree`
         fn _root_with_ctx(self: @ContractState, _zeroes: Array<u256>) -> u256 {
             let mut cur_idx = 0;
             let index = self.count.read();
@@ -205,6 +256,18 @@ pub mod merkle_tree_hook {
             };
             current.value
         }
+
+        /// Calculates and returns the merkle root for the given leaf, `_item`, a merkle branch, and the index of `_item` in the tree.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_item`- Merkle leaf
+        /// * - `_branch`- Merkle proof
+        /// * - `_index`- Index of `_item` in tree
+        /// 
+        /// # Returns
+        /// 
+        /// u256 - Calculated merkle root
         fn _branch_root(_item: ByteData, _branch: Span<ByteData>, _index: u256) -> u256 {
             let mut cur_idx = 0;
             let mut current = _item;
@@ -233,10 +296,17 @@ pub mod merkle_tree_hook {
             };
             current.value
         }
+
+        /// Calculates and returns`_tree`'s current root
+        /// 
+        /// # Returns
+        /// 
+        /// u256 - tree current root
         fn _root(self: @ContractState) -> u256 {
             self._root_with_ctx(self._zero_hashes())
         }
 
+        // build array tree from legacy map storage
         fn _build_tree(self: @ContractState) -> Array<ByteData> {
             let mut cur_idx = 0;
             let mut tree = array![];
@@ -254,7 +324,7 @@ pub mod merkle_tree_hook {
             0_u256
         }
 
-
+        // keccak256 zero hashes
         fn _zero_hashes(self: @ContractState) -> Array<u256> {
             array![
                 0x0000000000000000000000000000000000000000000000000000000000000000,
@@ -293,6 +363,16 @@ pub mod merkle_tree_hook {
         }
     }
 
+    /// Retrieve the i-th bit of a given index
+    /// 
+    /// # Arguments 
+    /// 
+    /// * - `_index`- index to retrieve the i-th bit from 
+    /// * - `i`- the position of the bit to retrieve
+    /// 
+    /// # Returns 
+    /// 
+    /// u256 - the i-th bit 
     fn _get_ith_bit(_index: u256, i: u32) -> u256 {
         let mask = pow(2.into(), i.into());
         (_index / mask) % 2

--- a/contracts/src/contracts/hooks/protocol_fee.cairo
+++ b/contracts/src/contracts/hooks/protocol_fee.cairo
@@ -86,7 +86,7 @@ pub mod protocol_fee {
         }
 
         /// Post action after a message is dispatched via the Mailbox
-        /// Dev: revert if invalid metadata variant
+        /// Dev: reverts if invalid metadata variant
         /// 
         /// # Arguments
         /// 
@@ -97,8 +97,8 @@ pub mod protocol_fee {
             self._post_dispatch(_metadata, _message);
         }
 
-        ///  Compute the payment required by the postDispatch call
-        /// Dev: revert if invalid metadata variant
+        ///  Computes the payment required by the postDispatch call
+        /// Dev: reverts if invalid metadata variant
         /// 
         /// # Arguments
         /// 

--- a/contracts/src/contracts/isms/aggregation/aggregation.cairo
+++ b/contracts/src/contracts/isms/aggregation/aggregation.cairo
@@ -130,7 +130,7 @@ pub mod aggregation {
             self.threshold.read()
         }
 
-        /// Set the ISM modules responsible for the verification
+        /// Sets the ISM modules responsible for the verification
         /// Dev: reverts if module address is null
         /// Dev: Callable only by the owner
         /// 
@@ -157,7 +157,7 @@ pub mod aggregation {
             }
         }
 
-        /// Set the threshold for validation
+        /// Sets the threshold for validation
         /// Dev: callable only by the owner
         /// 
         /// # Arguments
@@ -170,7 +170,7 @@ pub mod aggregation {
     }
     #[generate_trait]
     impl InternalImpl of InternalTrait {
-        /// Helper:  find the last module stored in the legacy map
+        /// Helper:  finds the last module stored in the legacy map
         /// 
         /// # Returns
         /// 
@@ -185,6 +185,11 @@ pub mod aggregation {
                 current_module = next_module;
             }
         }
+        /// Helper:  finds the index associated to a module in the legacy map
+        /// 
+        /// # Returns
+        /// 
+        /// Option<ContractAddress> - the contract if found, else None
         fn find_module_index(
             self: @ContractState, _module: ContractAddress
         ) -> Option<ContractAddress> {
@@ -200,6 +205,11 @@ pub mod aggregation {
             }
         }
 
+        /// Helper:  determines if a span of modules are already stored in the Storage Mapping
+        /// 
+        /// # Returns
+        /// 
+        /// boolean - True if at least one module is stored
         fn are_modules_stored(self: @ContractState, _modules: Span<ContractAddress>) -> bool {
             let mut cur_idx = 0;
             let mut result = false;
@@ -215,11 +225,11 @@ pub mod aggregation {
             result
         }
 
-        /// Helper:  Build a module span out of a stored legacy Map
+        /// Helper:  Build a module span out of a storage map
         /// 
         /// # Returns
         /// 
-        /// Span<ContractAddress> -a span of module addresses
+        /// Span<ContractAddress> - a span of module addresses
         fn build_modules_span(self: @ContractState) -> Span<ContractAddress> {
             let mut cur_address = contract_address_const::<0>();
             let mut modules = array![];

--- a/contracts/src/contracts/isms/multisig/merkleroot_multisig_ism.cairo
+++ b/contracts/src/contracts/isms/multisig/merkleroot_multisig_ism.cairo
@@ -9,11 +9,10 @@ pub mod merkleroot_multisig_ism {
         ModuleType, IInterchainSecurityModule, IInterchainSecurityModuleDispatcher,
         IInterchainSecurityModuleDispatcherTrait, IValidatorConfiguration,
     };
-    use hyperlane_starknet::utils::keccak256::{ByteData, HASH_SIZE};
+    use hyperlane_starknet::utils::keccak256::{ByteData, HASH_SIZE, bool_is_eth_signature_valid};
     use openzeppelin::access::ownable::OwnableComponent;
     use starknet::ContractAddress;
     use starknet::EthAddress;
-    use starknet::eth_signature::is_eth_signature_valid;
     use starknet::secp256_trait::{Signature, signature_from_vrs};
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -87,7 +86,7 @@ pub mod merkleroot_multisig_ism {
                         break false;
                     }
                     let signer = *validators.at(cur_idx);
-                    if self.bool_is_eth_signature_valid(digest, signature, signer) {
+                    if bool_is_eth_signature_valid(digest, signature, signer) {
                         // we found a match
                         break true;
                     }
@@ -212,14 +211,7 @@ pub mod merkleroot_multisig_ism {
             signature_from_vrs(v.into(), r, s)
         }
 
-        fn bool_is_eth_signature_valid(
-            self: @ContractState, msg_hash: u256, signature: Signature, signer: EthAddress
-        ) -> bool {
-            match is_eth_signature_valid(msg_hash, signature, signer) {
-                Result::Ok(()) => true,
-                Result::Err(_) => false
-            }
-        }
+    
         fn build_validators_span(self: @ContractState) -> Span<EthAddress> {
             let mut validators = ArrayTrait::new();
             let mut cur_idx = 0;

--- a/contracts/src/contracts/isms/multisig/merkleroot_multisig_ism.cairo
+++ b/contracts/src/contracts/isms/multisig/merkleroot_multisig_ism.cairo
@@ -61,7 +61,7 @@ pub mod merkleroot_multisig_ism {
         /// 
         /// # Arguments
         /// 
-        /// * - `_metadata` - encoded metadata (see aggregation_ism_metadata.cairo)
+        /// * - `_metadata` - encoded metadata (see merkleroot_ism_metadata.cairo)
         /// * - `_message` - message structure containing relevant information (see message.cairo)
         /// 
         /// # Returns 
@@ -168,6 +168,16 @@ pub mod merkleroot_multisig_ism {
 
     #[generate_trait]
     pub impl MerkleInternalImpl of InternalTrait {
+        /// Returns the digest to be used for signature verification.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded metadata (see merkleroot_ism_metadata.cairo)
+        /// * - `_message` - message structure containing relevant information (see message.cairo)
+        /// 
+        /// # Returns 
+        /// 
+        /// u256 - The digest to be signed by validators
         fn digest(self: @ContractState, _metadata: Bytes, _message: Message) -> u256 {
             assert(
                 MerkleRootIsmMetadata::message_index(
@@ -206,12 +216,22 @@ pub mod merkleroot_multisig_ism {
             )
         }
 
+        /// Returns the signature at a given index from the metadata.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded metadata (see merkleroot_ism_metadata.cairo)
+        /// * - `_index` - The index of the signature to return
+        /// 
+        /// # Returns 
+        /// 
+        /// Signature  - A formatted signature (see Signature structure)
         fn get_signature_at(self: @ContractState, _metadata: Bytes, _index: u32) -> Signature {
             let (v, r, s) = MerkleRootIsmMetadata::signature_at(_metadata, _index);
             signature_from_vrs(v.into(), r, s)
         }
 
-    
+        /// Helper: buils an span of Ethereum validators addresses from the Storage Map
         fn build_validators_span(self: @ContractState) -> Span<EthAddress> {
             let mut validators = ArrayTrait::new();
             let mut cur_idx = 0;

--- a/contracts/src/contracts/isms/multisig/messageid_multisig_ism.cairo
+++ b/contracts/src/contracts/isms/multisig/messageid_multisig_ism.cairo
@@ -1,7 +1,6 @@
 #[starknet::contract]
 pub mod messageid_multisig_ism {
-    use alexandria_bytes::{Bytes, BytesTrait, BytesStore};
-    use core::ecdsa::check_ecdsa_signature;
+    use alexandria_bytes::{Bytes, BytesTrait};
     use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::CheckpointLib;
     use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait};
     use hyperlane_starknet::contracts::libs::multisig::message_id_ism_metadata::message_id_ism_metadata::MessageIdIsmMetadata;
@@ -59,6 +58,18 @@ pub mod messageid_multisig_ism {
             ModuleType::MESSAGE_ID_MULTISIG(starknet::get_contract_address())
         }
 
+        /// Requires that m-of-n ISMs verify the provided interchain message.
+        /// Dev: Can change based on the content of _message
+        /// Dev: Reverts if threshold is not set or no match for signature
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded metadata (see aggregation_ism_metadata.cairo)
+        /// * - `_message` - message structure containing relevant information (see message.cairo)
+        /// 
+        /// # Returns 
+        /// 
+        /// boolean - wheter the verification succeed or not.
         fn verify(self: @ContractState, _metadata: Bytes, _message: Message,) -> bool {
             assert(_metadata.clone().size() > 0, Errors::EMPTY_METADATA);
             let digest = digest(_metadata.clone(), _message.clone());
@@ -102,6 +113,12 @@ pub mod messageid_multisig_ism {
             self.threshold.read()
         }
 
+        /// Sets a span of validators responsible to verify the message
+        /// Dev: callable only by the admin
+        /// 
+        /// # Arguments 
+        ///
+        /// * - `_validators` - a span of validators to set
         fn set_validators(ref self: ContractState, _validators: Span<EthAddress>) {
             self.ownable.assert_only_owner();
             let mut cur_idx = 0;

--- a/contracts/src/contracts/isms/multisig/validator_announce.cairo
+++ b/contracts/src/contracts/isms/multisig/validator_announce.cairo
@@ -8,7 +8,9 @@ pub mod validator_announce {
         MailboxclientComponent::MailboxClientImpl
     };
     use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::HYPERLANE_ANNOUNCEMENT;
-    use hyperlane_starknet::interfaces::{IMailboxClientDispatcher, IMailboxClientDispatcherTrait, IValidatorAnnounce};
+    use hyperlane_starknet::interfaces::{
+        IMailboxClientDispatcher, IMailboxClientDispatcherTrait, IValidatorAnnounce
+    };
     use hyperlane_starknet::utils::keccak256::{
         reverse_endianness, to_eth_signature, compute_keccak, ByteData, u256_word_size,
         u64_word_size, HASH_SIZE, bool_is_eth_signature_valid
@@ -16,7 +18,9 @@ pub mod validator_announce {
     use hyperlane_starknet::utils::store_arrays::StoreFelt252Array;
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
-    use starknet::{ContractAddress, ClassHash,EthAddress,secp256_trait::{Signature, signature_from_vrs} };
+    use starknet::{
+        ContractAddress, ClassHash, EthAddress, secp256_trait::{Signature, signature_from_vrs}
+    };
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
@@ -150,7 +154,7 @@ pub mod validator_announce {
         /// 
         /// # Arguments
         /// 
-        /// * - `_validators` - The list of validators to get registrations for
+        /// * - `_validators` - The span of validators to get registrations for
         /// 
         /// # Returns 
         /// 
@@ -215,7 +219,15 @@ pub mod validator_announce {
 
     #[generate_trait]
     pub impl ValidatorAnnounceInternalImpl of InternalTrait {
-
+        /// Converts a byte signature into a standard singature format (see Signature structure)
+        /// 
+        /// # Arguments
+        /// 
+        /// * - ` _signature` - The byte encoded Signature
+        /// 
+        /// # Returns
+        /// 
+        /// Signature - Standardized signature
         fn convert_to_signature(self: @ContractState, _signature: Bytes) -> Signature {
             let (_, r) = _signature.read_u256(0);
             let (_, s) = _signature.read_u256(32);
@@ -240,7 +252,16 @@ pub mod validator_announce {
             reverse_endianness(compute_keccak(input.span()))
         }
 
-
+        /// Helper: finds the index associated to a given validator, if found
+        /// Dev: Chained list (EthereumAddress -> EthereumAddress)
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_validator` - The validator to consider
+        /// 
+        /// # Returns 
+        /// 
+        /// EthAddress - the index of the validator in the Storage Map
         fn find_validators_index(
             self: @ContractState, _validator: EthAddress
         ) -> Option<EthAddress> {
@@ -256,6 +277,7 @@ pub mod validator_announce {
             }
         }
 
+        /// Helper: finds the last stored validator
         fn find_last_validator(self: @ContractState) -> EthAddress {
             let mut current_validator = self.validators.read(0.try_into().unwrap());
             loop {
@@ -267,6 +289,7 @@ pub mod validator_announce {
             }
         }
 
+        // Helper: builds a span of validators from the storage map
         fn build_validators_array(self: @ContractState) -> Span<EthAddress> {
             let mut index = 0.try_into().unwrap();
             let mut validators = array![];

--- a/contracts/src/contracts/isms/noop_ism.cairo
+++ b/contracts/src/contracts/isms/noop_ism.cairo
@@ -15,6 +15,18 @@ pub mod noop_ism {
             ModuleType::NULL(())
         }
 
+        /// Requires that m-of-n ISMs verify the provided interchain message.
+        /// Dev: Can change based on the content of _message
+        /// Dev: Reverts if threshold is not set
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded metadata (see aggregation_ism_metadata.cairo)
+        /// * - `_message` - message structure containing relevant information (see message.cairo)
+        /// 
+        /// # Returns 
+        /// 
+        /// boolean - wheter the verification succeed or not.
         fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
             true
         }

--- a/contracts/src/contracts/isms/pausable_ism.cairo
+++ b/contracts/src/contracts/isms/pausable_ism.cairo
@@ -17,7 +17,7 @@ pub mod pausable_ism {
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::security::pausable::PausableComponent;
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
-    use starknet::{ContractAddress,ClassHash};
+    use starknet::{ContractAddress, ClassHash};
     use super::{IPausableIsm, IPausableIsmDispatcher, IPausableIsmDispatcherTrait,};
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);

--- a/contracts/src/contracts/isms/pausable_ism.cairo
+++ b/contracts/src/contracts/isms/pausable_ism.cairo
@@ -17,7 +17,7 @@ pub mod pausable {
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::security::pausable::PausableComponent;
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
-    use starknet::{ContractAddress, contract_address_const};
+    use starknet::{ContractAddress,ClassHash};
     use super::{IPausableIsm, IPausableIsmDispatcher, IPausableIsmDispatcherTrait,};
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -66,9 +66,33 @@ pub mod pausable {
             ModuleType::NULL(())
         }
 
+        /// Requires that m-of-n ISMs verify the provided interchain message.
+        /// Dev: Can change based on the content of _message
+        /// Dev: Reverts if threshold is not set
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded metadata (see aggregation_ism_metadata.cairo)
+        /// * - `_message` - message structure containing relevant information (see message.cairo)
+        /// 
+        /// # Returns 
+        /// 
+        /// boolean - wheter the verification succeed or not.
         fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
             self.pausable.assert_not_paused();
             true
+        }
+    }
+    #[abi(embed_v0)]
+    impl Upgradeable of IUpgradeable<ContractState> {
+        /// Upgrades the contract to a new implementation.
+        /// Callable only by the owner
+        /// # Arguments
+        ///
+        /// * `new_class_hash` - The class hash of the new implementation.
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            self.ownable.assert_only_owner();
+            self.upgradeable._upgrade(new_class_hash);
         }
     }
 

--- a/contracts/src/contracts/isms/trusted_relayer_ism.cairo
+++ b/contracts/src/contracts/isms/trusted_relayer_ism.cairo
@@ -27,6 +27,18 @@ pub mod trusted_relayer_ism {
             ModuleType::NULL(())
         }
 
+        /// Requires that m-of-n ISMs verify the provided interchain message.
+        /// Dev: Can change based on the content of _message
+        /// Dev: Reverts if threshold is not set
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_metadata` - encoded metadata (see aggregation_ism_metadata.cairo)
+        /// * - `_message` - message structure containing relevant information (see message.cairo)
+        /// 
+        /// # Returns 
+        /// 
+        /// boolean - wheter the verification succeed or not.
         fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
             let mailbox = IMailboxDispatcher { contract_address: self.mailbox.read() };
             let (id, _) = MessageTrait::format_message(_message);

--- a/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
@@ -75,7 +75,7 @@ pub mod aggregation_ism_metadata {
     /// # Returns
     /// 
     /// Result<u32, u32), u8> -  Result on whether or not metadata was provided for the ISM at `_index`
-    fn metadata_range(_metadata: Bytes, _index: u8) -> Result<(u32, u32),u8>{
+    fn metadata_range(_metadata: Bytes, _index: u8) -> Result<(u32, u32), u8> {
         let start = _index.into() * RANGE_SIZE * 2;
         let mid = start + RANGE_SIZE;
         let (_, mid_metadata) = _metadata.read_u32(mid.into());

--- a/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
@@ -6,11 +6,27 @@ pub mod aggregation_ism_metadata {
         fn metadata_at(_metadata: Bytes, _index: u8) -> Bytes;
         fn has_metadata(_metadata: Bytes, _index: u8) -> bool;
     }
-
+    /// * Format of metadata:
+    /// *
+    /// * [????:????] Metadata start/end uint32 ranges, packed as uint64
+    /// * [????:????] ISM metadata, packed encoding
+    /// *
     const RANGE_SIZE: u8 = 4;
     const BYTES_PER_ELEMENT: u8 = 16;
 
     impl AggregationIsmMetadataImpl of AggregationIsmMetadata {
+        /// Returns the metadata provided for the ISM at `_index`
+        /// Dev: Callers must ensure _index is less than the number of metadatas provided
+        /// Dev: Callers must ensure `hasMetadata(_metadata, _index)`
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` -Encoded Aggregation ISM metadata
+        /// * - `_index` - The index of the ISM to check for metadata for
+        /// 
+        /// # Returns
+        /// 
+        /// Bytes -  The metadata provided for the ISM at `_index`
         fn metadata_at(_metadata: Bytes, _index: u8) -> Bytes {
             let (mut start, end) = match metadata_range(_metadata.clone(), _index) {
                 Result::Ok((start, end)) => (start, end),
@@ -29,6 +45,17 @@ pub mod aggregation_ism_metadata {
             };
             bytes_array
         }
+        /// Returns whether or not metadata was provided for the ISM at _index
+        /// Dev: Callers must ensure _index is less than the number of metadatas provided
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` -Encoded Aggregation ISM metadata
+        /// * - `_index` - The index of the ISM to check for metadata for
+        /// 
+        /// # Returns
+        /// 
+        /// boolean -  Whether or not metadata was provided for the ISM at `_index`
         fn has_metadata(_metadata: Bytes, _index: u8) -> bool {
             match metadata_range(_metadata, _index) {
                 Result::Ok((_, _)) => true,
@@ -37,7 +64,18 @@ pub mod aggregation_ism_metadata {
         }
     }
 
-    fn metadata_range(_metadata: Bytes, _index: u8) -> Result<(u32, u32), u8> {
+    /// Returns the range of the metadata provided for the ISM at _index
+    /// Dev: Callers must ensure _index is less than the number of metadatas provided
+    /// 
+    /// # Arguments
+    ///
+    /// * - `_metadata` -Encoded Aggregation ISM metadata
+    /// * - `_index` - The index of the ISM to check for metadata for
+    /// 
+    /// # Returns
+    /// 
+    /// Result<u32, u32), u8> -  Result on whether or not metadata was provided for the ISM at `_index`
+    fn metadata_range(_metadata: Bytes, _index: u8) -> Result<(u32, u32),u8>{
         let start = _index.into() * RANGE_SIZE * 2;
         let mid = start + RANGE_SIZE;
         let (_, mid_metadata) = _metadata.read_u32(mid.into());

--- a/contracts/src/contracts/libs/checkpoint_lib.cairo
+++ b/contracts/src/contracts/libs/checkpoint_lib.cairo
@@ -57,7 +57,7 @@ pub mod checkpoint_lib {
             to_eth_signature(reverse_endianness(compute_keccak(input.span())))
         }
 
-        /// Returns the domain hash that validators are expected to use when signing checkpoints.
+        /// Returns the domain hash validators are expected to use when signing checkpoints.
         /// 
         /// # Arguments
         /// 

--- a/contracts/src/contracts/libs/checkpoint_lib.cairo
+++ b/contracts/src/contracts/libs/checkpoint_lib.cairo
@@ -20,6 +20,19 @@ pub mod checkpoint_lib {
     pub const HYPERLANE_ANNOUNCEMENT: felt252 = 'HYPERLANE_ANNOUNCEMENT';
 
     impl CheckpointLibImpl of CheckpointLib {
+        /// Returns the digest validators are expected to sign when signing checkpoints.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_origin` - The origin domain of the checkpoint.
+        /// * - `_origin_merkle_tree_hook` - The address of the origin merkle tree hook 
+        /// * - `_checkpoint_root` -  The root of the checkpoint.
+        /// * - `_checkpoint_index` - The index of the checkpoint.
+        /// * - `_message_id` - The message ID of the checkpoint.
+        /// 
+        /// # Returns 
+        /// 
+        /// u256 - the digest 
         fn digest(
             _origin: u32,
             _origin_merkle_tree_hook: u256,
@@ -43,6 +56,16 @@ pub mod checkpoint_lib {
             compute_keccak(input.span())
         }
 
+        /// Returns the domain hash that validators are expected to use when signing checkpoints.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_origin` - The origin domain of the checkpoint.
+        /// * - `_origin_merkle_tree_hook` - The address of the origin merkle tree hook 
+        /// 
+        /// # Returns 
+        /// 
+        /// u256 -  The domain hash.
         fn domain_hash(_origin: u32, _origin_merkle_tree_hook: u256) -> u256 {
             let mut input: Array<ByteData> = array![
                 ByteData { value: _origin.into(), size: u64_word_size(_origin.into()).into() },

--- a/contracts/src/contracts/libs/message.cairo
+++ b/contracts/src/contracts/libs/message.cairo
@@ -1,5 +1,4 @@
 use alexandria_bytes::{Bytes, BytesTrait, BytesStore};
-use core::poseidon::poseidon_hash_span;
 use hyperlane_starknet::utils::keccak256::{
     reverse_endianness, compute_keccak, ByteData, u256_word_size, u64_word_size, ADDRESS_SIZE
 };
@@ -39,7 +38,7 @@ pub impl MessageImpl of MessageTrait {
         }
     }
 
-    /// Format an input message, using reverse keccak big endian
+    /// Format an input message, using 
     /// 
     /// # Arguments
     /// 

--- a/contracts/src/contracts/libs/message.cairo
+++ b/contracts/src/contracts/libs/message.cairo
@@ -87,6 +87,6 @@ pub impl MessageImpl of MessageTrait {
                 Option::None(_) => { break (); }
             };
         };
-        (compute_keccak(input.span()), _message)
+        (reverse_endianness(compute_keccak(input.span())), _message)
     }
 }

--- a/contracts/src/contracts/libs/multisig/merkleroot_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/multisig/merkleroot_ism_metadata.cairo
@@ -30,22 +30,69 @@ pub mod merkleroot_ism_metadata {
     pub const SIGNATURES_OFFSET: u32 = 1096;
     pub const SIGNATURE_LENGTH: u32 = 65;
     impl MerkleRootIsmMetadataImpl of MerkleRootIsmMetadata {
+        /// Returns the origin merkle tree hook of the signed checkpoint 
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` - encoded multisig ISM metadata
+        /// 
+        /// # Returns
+        /// 
+        /// u256 -   Origin merkle tree hook of the signed checkpoint 
         fn origin_merkle_tree_hook(_metadata: Bytes) -> u256 {
             let (_, felt) = _metadata.read_u256(ORIGIN_MERKLE_TREE_OFFSET);
             felt
         }
+
+        /// Returns the index of the message being proven.
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` - encoded multisig ISM metadata
+        /// 
+        /// # Returns
+        /// 
+        /// u32 -   Index of the target message in the merkle tree.
         fn message_index(_metadata: Bytes) -> u32 {
             let (_, felt) = _metadata.read_u32(MESSAGE_INDEX_OFFSET);
             felt
         }
+       
+        /// Returns the index of the signed checkpoint.
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` - encoded multisig ISM metadata
+        /// 
+        /// # Returns
+        /// 
+        /// u32 -   Index of the signed checkpoint
         fn signed_index(_metadata: Bytes) -> u32 {
             let (_, felt) = _metadata.read_u32(SIGNED_INDEX_OFFSET);
             felt
         }
+        /// Returns the message ID of the signed checkpoint.
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` - encoded multisig ISM metadata
+        /// 
+        /// # Returns
+        /// 
+        /// u256 -   Message ID of the signed checkpoint
         fn signed_message_id(_metadata: Bytes) -> u256 {
             let (_, felt) = _metadata.read_u256(MESSAGE_ID_OFFSET);
             felt
         }
+        /// Returns the merkle proof branch of the message.
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` - encoded multisig ISM metadata
+        /// 
+        /// # Returns
+        /// 
+        /// Span<u256> -  Merkle proof branch of the message.
         fn proof(_metadata: Bytes) -> Span<u256> {
             let mut bytes_arr = array![];
             let mut cur_idx = 0;
@@ -60,7 +107,18 @@ pub mod merkleroot_ism_metadata {
             };
             bytes_arr.span()
         }
-
+        /// Returns the validator ECDSA signature at `_index`.
+        /// Dev: Assumes signatures are sorted by validator
+        /// Dev: Assumes `_metadata` encodes `threshold` signatures.
+        /// Dev: Assumes `_index` is less than `threshold`
+        /// # Arguments
+        ///
+        /// * - `_metadata` - encoded multisig ISM metadata
+        /// * - `_index` - The index of the signature to return.
+        /// 
+        /// # Returns
+        /// 
+        /// (u8, u256, u256) -  The validator ECDSA signature at `_index`.
         fn signature_at(_metadata: Bytes, _index: u32) -> (u8, u256, u256) {
             // the first signer index is 0
             let (index_r, r) = _metadata.read_u256(SIGNATURES_OFFSET + SIGNATURE_LENGTH * _index);

--- a/contracts/src/contracts/libs/multisig/merkleroot_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/multisig/merkleroot_ism_metadata.cairo
@@ -57,7 +57,7 @@ pub mod merkleroot_ism_metadata {
             let (_, felt) = _metadata.read_u32(MESSAGE_INDEX_OFFSET);
             felt
         }
-       
+
         /// Returns the index of the signed checkpoint.
         /// 
         /// # Arguments

--- a/contracts/src/contracts/libs/multisig/message_id_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/multisig/message_id_ism_metadata.cairo
@@ -10,11 +10,11 @@ pub mod message_id_ism_metadata {
     }
 
 
-/// * Format of metadata:
-/// * [   0:  32] Origin merkle tree address
-/// * [  32:  64] Signed checkpoint root
-/// * [  64:  68] Signed checkpoint index
-/// * [  68:????] Validator signatures (length := threshold * 65)
+    /// * Format of metadata:
+    /// * [   0:  32] Origin merkle tree address
+    /// * [  32:  64] Signed checkpoint root
+    /// * [  64:  68] Signed checkpoint index
+    /// * [  68:????] Validator signatures (length := threshold * 65)
 
     pub const ORIGIN_MERKLE_TREE_HOOK_OFFSET: u32 = 0;
     pub const ROOT_OFFSET: u32 = 32;

--- a/contracts/src/contracts/libs/multisig/message_id_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/multisig/message_id_ism_metadata.cairo
@@ -57,7 +57,7 @@ pub mod message_id_ism_metadata {
         /// 
         /// # Returns
         /// 
-        /// u256 -   Merkle index of the signed checkpoint
+        /// u32 -   Merkle index of the signed checkpoint
         fn index(_metadata: Bytes) -> u32 {
             let (_, felt) = _metadata.read_u32(INDEX_OFFSET);
             felt
@@ -75,7 +75,7 @@ pub mod message_id_ism_metadata {
         /// 
         /// # Returns
         /// 
-        /// u256 -  The validator ECDSA signature at `_index`.
+        /// (u8, u256, u256) -  The validator ECDSA signature at `_index`.
         fn signature_at(_metadata: Bytes, _index: u32) -> (u8, u256, u256) {
             // signature length set to 80 because u128 padding from the v param
             let (index_r, r) = _metadata.read_u256(SIGNATURE_OFFSET + SIGNATURE_LENGTH * _index);

--- a/contracts/src/contracts/libs/multisig/message_id_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/multisig/message_id_ism_metadata.cairo
@@ -8,27 +8,74 @@ pub mod message_id_ism_metadata {
         fn index(_metadata: Bytes) -> u32;
         fn signature_at(_metadata: Bytes, _index: u32) -> (u8, u256, u256);
     }
+
+
+/// * Format of metadata:
+/// * [   0:  32] Origin merkle tree address
+/// * [  32:  64] Signed checkpoint root
+/// * [  64:  68] Signed checkpoint index
+/// * [  68:????] Validator signatures (length := threshold * 65)
+
     pub const ORIGIN_MERKLE_TREE_HOOK_OFFSET: u32 = 0;
     pub const ROOT_OFFSET: u32 = 32;
     pub const INDEX_OFFSET: u32 = 64;
     pub const SIGNATURE_OFFSET: u32 = 68;
     pub const SIGNATURE_LENGTH: u32 = 65;
     impl MessagIdIsmMetadataImpl of MessageIdIsmMetadata {
+        /// Returns the origin merkle tree hook of the signed checkpoint 
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` -Encoded MultisigISM metadata
+        /// 
+        /// # Returns
+        /// 
+        /// u256 -   Origin merkle tree hook of the signed checkpoint 
         fn origin_merkle_tree_hook(_metadata: Bytes) -> u256 {
             let (_, felt) = _metadata.read_u256(ORIGIN_MERKLE_TREE_HOOK_OFFSET);
             felt
         }
 
+        /// Returns the merkle root of the signed checkpoint.
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` -Encoded MultisigISM metadata
+        /// 
+        /// # Returns
+        /// 
+        /// u256 -    Merkle root of the signed checkpoint
         fn root(_metadata: Bytes) -> u256 {
             let (_, felt) = _metadata.read_u256(ROOT_OFFSET);
             felt
         }
-
+        /// Returns the merkle index of the signed checkpoint.
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` -Encoded MultisigISM metadata
+        /// 
+        /// # Returns
+        /// 
+        /// u256 -   Merkle index of the signed checkpoint
         fn index(_metadata: Bytes) -> u32 {
             let (_, felt) = _metadata.read_u32(INDEX_OFFSET);
             felt
         }
 
+        /// Returns the validator ECDSA signature at `_index`.
+        /// Dev: Assumes signatures are sorted by validator
+        /// Assumes `_metadata` encodes `threshold` signatures.
+        /// Assumes `_index` is less than `threshold`
+        /// 
+        /// # Arguments
+        ///
+        /// * - `_metadata` -Encoded MultisigISM metadata
+        /// * - `_index` - The index of the signature to return.
+        /// 
+        /// # Returns
+        /// 
+        /// u256 -  The validator ECDSA signature at `_index`.
         fn signature_at(_metadata: Bytes, _index: u32) -> (u8, u256, u256) {
             // signature length set to 80 because u128 padding from the v param
             let (index_r, r) = _metadata.read_u256(SIGNATURE_OFFSET + SIGNATURE_LENGTH * _index);

--- a/contracts/src/contracts/mailbox.cairo
+++ b/contracts/src/contracts/mailbox.cairo
@@ -1,7 +1,6 @@
 #[starknet::contract]
 pub mod mailbox {
-    use alexandria_bytes::{Bytes, BytesTrait, BytesStore};
-    use core::starknet::SyscallResultTrait;
+    use alexandria_bytes::{Bytes, BytesTrait};
     use core::starknet::event::EventEmitter;
     use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERLANE_VERSION};
     use hyperlane_starknet::interfaces::{

--- a/contracts/src/contracts/mocks/mock_validator_announce.cairo
+++ b/contracts/src/contracts/mocks/mock_validator_announce.cairo
@@ -10,7 +10,7 @@ pub mod mock_validator_announce {
     use hyperlane_starknet::interfaces::{IMailboxClientDispatcher, IMailboxClientDispatcherTrait};
     use hyperlane_starknet::utils::keccak256::{
         reverse_endianness, to_eth_signature, compute_keccak, ByteData, u64_word_size,
-        u256_word_size, HASH_SIZE,bool_is_eth_signature_valid
+        u256_word_size, HASH_SIZE, bool_is_eth_signature_valid
     };
     use hyperlane_starknet::utils::store_arrays::StoreFelt252Array;
 
@@ -164,7 +164,6 @@ pub mod mock_validator_announce {
         ];
         reverse_endianness(compute_keccak(input.span()))
     }
-
 
 
     fn find_validators_index(self: @ContractState, _validator: EthAddress) -> Option<EthAddress> {

--- a/contracts/src/contracts/mocks/mock_validator_announce.cairo
+++ b/contracts/src/contracts/mocks/mock_validator_announce.cairo
@@ -10,13 +10,12 @@ pub mod mock_validator_announce {
     use hyperlane_starknet::interfaces::{IMailboxClientDispatcher, IMailboxClientDispatcherTrait};
     use hyperlane_starknet::utils::keccak256::{
         reverse_endianness, to_eth_signature, compute_keccak, ByteData, u64_word_size,
-        u256_word_size, HASH_SIZE,
+        u256_word_size, HASH_SIZE,bool_is_eth_signature_valid
     };
     use hyperlane_starknet::utils::store_arrays::StoreFelt252Array;
 
     use starknet::ContractAddress;
     use starknet::EthAddress;
-    use starknet::eth_signature::is_eth_signature_valid;
     use starknet::secp256_trait::{Signature, signature_from_vrs};
 
     #[storage]
@@ -167,14 +166,6 @@ pub mod mock_validator_announce {
     }
 
 
-    fn bool_is_eth_signature_valid(
-        msg_hash: u256, signature: Signature, signer: EthAddress
-    ) -> bool {
-        match is_eth_signature_valid(msg_hash, signature, signer) {
-            Result::Ok(()) => true,
-            Result::Err(_) => false
-        }
-    }
 
     fn find_validators_index(self: @ContractState, _validator: EthAddress) -> Option<EthAddress> {
         let mut current_validator: EthAddress = 0.try_into().unwrap();

--- a/contracts/src/tests/hooks/test_merkle_tree_hook.cairo
+++ b/contracts/src/tests/hooks/test_merkle_tree_hook.cairo
@@ -7,8 +7,8 @@ use hyperlane_starknet::interfaces::{
     IMerkleTreeHookDispatcherTrait
 };
 use hyperlane_starknet::tests::setup::{
-    setup_merkle_tree_hook, setup, MAILBOX, LOCAL_DOMAIN, VALID_OWNER,
-    VALID_RECIPIENT, DESTINATION_DOMAIN
+    setup_merkle_tree_hook, setup, MAILBOX, LOCAL_DOMAIN, VALID_OWNER, VALID_RECIPIENT,
+    DESTINATION_DOMAIN
 };
 use hyperlane_starknet::utils::keccak256::{ByteData, HASH_SIZE};
 use merkle_tree_hook::{InternalTrait, treeContractMemberStateTrait, countContractMemberStateTrait};

--- a/contracts/src/tests/hooks/test_merkle_tree_hook.cairo
+++ b/contracts/src/tests/hooks/test_merkle_tree_hook.cairo
@@ -1,6 +1,4 @@
 use alexandria_bytes::{Bytes, BytesTrait};
-use core::option::OptionTrait;
-use core::traits::TryInto;
 use hyperlane_starknet::contracts::hooks::merkle_tree_hook::merkle_tree_hook;
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERLANE_VERSION};
 use hyperlane_starknet::interfaces::{
@@ -9,15 +7,14 @@ use hyperlane_starknet::interfaces::{
     IMerkleTreeHookDispatcherTrait
 };
 use hyperlane_starknet::tests::setup::{
-    setup_merkle_tree_hook, setup, MAILBOX, RECIPIENT_ADDRESS, OWNER, LOCAL_DOMAIN, VALID_OWNER,
+    setup_merkle_tree_hook, setup, MAILBOX, LOCAL_DOMAIN, VALID_OWNER,
     VALID_RECIPIENT, DESTINATION_DOMAIN
 };
-use hyperlane_starknet::utils::keccak256::{compute_keccak, ByteData, HASH_SIZE};
+use hyperlane_starknet::utils::keccak256::{ByteData, HASH_SIZE};
 use merkle_tree_hook::{InternalTrait, treeContractMemberStateTrait, countContractMemberStateTrait};
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::cheatcodes::events::EventAssertions;
-use snforge_std::{start_prank, CheatTarget, stop_prank};
-use starknet::contract_address_const;
+use snforge_std::{start_prank, CheatTarget};
 
 #[test]
 fn test_merkle_tree_hook_type() {

--- a/contracts/src/tests/hooks/test_protocol_fee.cairo
+++ b/contracts/src/tests/hooks/test_protocol_fee.cairo
@@ -1,4 +1,4 @@
-use alexandria_bytes::{Bytes, BytesTrait, BytesStore};
+use alexandria_bytes::{Bytes, BytesTrait};
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait};
 use hyperlane_starknet::interfaces::{
     Types, IProtocolFeeDispatcher, IProtocolFeeDispatcherTrait, IPostDispatchHookDispatcher,
@@ -8,9 +8,8 @@ use hyperlane_starknet::tests::setup::{
     setup_protocol_fee, OWNER, MAX_PROTOCOL_FEE, BENEFICIARY, PROTOCOL_FEE, INITIAL_SUPPLY
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 use snforge_std::{start_prank, CheatTarget, stop_prank};
-use starknet::{get_caller_address};
 
 
 #[test]

--- a/contracts/src/tests/isms/test_aggregation.cairo
+++ b/contracts/src/tests/isms/test_aggregation.cairo
@@ -1,20 +1,19 @@
 use alexandria_bytes::{Bytes, BytesTrait};
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERLANE_VERSION};
 use hyperlane_starknet::interfaces::{
-    ModuleType, IAggregation, IAggregationDispatcher, IAggregationDispatcherTrait,
+    ModuleType, IAggregationDispatcher, IAggregationDispatcherTrait,
     IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
     IValidatorConfigurationDispatcher, IValidatorConfigurationDispatcherTrait,
-    IValidatorConfiguration, IInterchainSecurityModule
 };
 use hyperlane_starknet::tests::setup::{
     setup_aggregation, OWNER, setup_messageid_multisig_ism, get_message_and_signature, LOCAL_DOMAIN,
-    DESTINATION_DOMAIN, RECIPIENT_ADDRESS, setup_merkleroot_multisig_ism, build_messageid_metadata,
-    VALID_OWNER, VALID_RECIPIENT, get_merkle_message_and_signature, build_merkle_metadata,
+    DESTINATION_DOMAIN, build_messageid_metadata,
+    VALID_OWNER, VALID_RECIPIENT,
     setup_noop_ism
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use snforge_std::{start_prank, CheatTarget, stop_prank};
+use snforge_std::{start_prank, CheatTarget};
 use starknet::ContractAddress;
 
 #[test]

--- a/contracts/src/tests/isms/test_aggregation.cairo
+++ b/contracts/src/tests/isms/test_aggregation.cairo
@@ -7,9 +7,7 @@ use hyperlane_starknet::interfaces::{
 };
 use hyperlane_starknet::tests::setup::{
     setup_aggregation, OWNER, setup_messageid_multisig_ism, get_message_and_signature, LOCAL_DOMAIN,
-    DESTINATION_DOMAIN, build_messageid_metadata,
-    VALID_OWNER, VALID_RECIPIENT,
-    setup_noop_ism
+    DESTINATION_DOMAIN, build_messageid_metadata, VALID_OWNER, VALID_RECIPIENT, setup_noop_ism
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};

--- a/contracts/src/tests/isms/test_default_ism.cairo
+++ b/contracts/src/tests/isms/test_default_ism.cairo
@@ -1,8 +1,8 @@
 use alexandria_bytes::{Bytes, BytesTrait};
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERLANE_VERSION};
 use hyperlane_starknet::interfaces::{
-    ModuleType, IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait, IMailboxDispatcher, IMailboxDispatcherTrait, IPausableIsmDispatcher,
-    IPausableIsmDispatcherTrait
+    ModuleType, IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
+    IMailboxDispatcher, IMailboxDispatcherTrait, IPausableIsmDispatcher, IPausableIsmDispatcherTrait
 };
 use hyperlane_starknet::tests::setup::{
     setup, setup_trusted_relayer_ism, setup_noop_ism, setup_pausable_ism, mock_setup,

--- a/contracts/src/tests/isms/test_default_ism.cairo
+++ b/contracts/src/tests/isms/test_default_ism.cairo
@@ -1,8 +1,7 @@
 use alexandria_bytes::{Bytes, BytesTrait};
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERLANE_VERSION};
 use hyperlane_starknet::interfaces::{
-    ModuleType, IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
-    IMailbox, IMailboxDispatcher, IMailboxDispatcherTrait, IPausableIsm, IPausableIsmDispatcher,
+    ModuleType, IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait, IMailboxDispatcher, IMailboxDispatcherTrait, IPausableIsmDispatcher,
     IPausableIsmDispatcherTrait
 };
 use hyperlane_starknet::tests::setup::{
@@ -10,7 +9,7 @@ use hyperlane_starknet::tests::setup::{
     DESTINATION_DOMAIN, OWNER, LOCAL_DOMAIN, MAILBOX
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use snforge_std::{start_prank, CheatTarget, stop_prank};
+use snforge_std::{start_prank, CheatTarget};
 
 
 #[test]

--- a/contracts/src/tests/isms/test_merkleroot_multisig.cairo
+++ b/contracts/src/tests/isms/test_merkleroot_multisig.cairo
@@ -1,37 +1,25 @@
 use alexandria_bytes::{Bytes, BytesTrait};
-use alexandria_data_structures::array_ext::ArrayTraitExt;
 use core::array::ArrayTrait;
 use core::array::SpanTrait;
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERLANE_VERSION};
-use hyperlane_starknet::contracts::libs::multisig::merkleroot_ism_metadata::merkleroot_ism_metadata::{
-    MerkleRootIsmMetadata, MERKLE_PROOF_ITERATION
-};
-use hyperlane_starknet::contracts::mailbox::mailbox;
+use hyperlane_starknet::contracts::libs::multisig::merkleroot_ism_metadata::merkleroot_ism_metadata::MerkleRootIsmMetadata;
 use hyperlane_starknet::interfaces::IMessageRecipientDispatcherTrait;
 use hyperlane_starknet::interfaces::{
-    IMailbox, IMailboxDispatcher, IMailboxDispatcherTrait, ModuleType,
+    IMailboxDispatcher, IMailboxDispatcherTrait, ModuleType,
     IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
     IInterchainSecurityModule, IValidatorConfigurationDispatcher,
     IValidatorConfigurationDispatcherTrait,
 };
 use hyperlane_starknet::tests::setup::{
-    setup, mock_setup, setup_merkleroot_multisig_ism, OWNER, NEW_OWNER, VALIDATOR_ADDRESS_1,
-    VALIDATOR_ADDRESS_2, setup_validator_announce, get_merkle_message_and_signature, LOCAL_DOMAIN,
-    DESTINATION_DOMAIN, RECIPIENT_ADDRESS, TEST_PROOF, build_merkle_metadata, VALID_OWNER,
+    setup, setup_merkleroot_multisig_ism, OWNER, NEW_OWNER, VALIDATOR_ADDRESS_1,
+    VALIDATOR_ADDRESS_2, get_merkle_message_and_signature, LOCAL_DOMAIN,
+    DESTINATION_DOMAIN, TEST_PROOF, build_merkle_metadata, VALID_OWNER,
     VALID_RECIPIENT
 };
-use hyperlane_starknet::utils::keccak256::{
-    reverse_endianness, to_eth_signature, compute_keccak, ByteData, u256_word_size, u64_word_size
-};
-
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::cheatcodes::events::EventAssertions;
-use snforge_std::{start_prank, CheatTarget, stop_prank};
-use starknet::eth_address::EthAddress;
-use starknet::eth_signature::verify_eth_signature;
-use starknet::secp256_trait::Signature;
-use starknet::secp256_trait::signature_from_vrs;
+use snforge_std::{start_prank, CheatTarget};
 
 #[test]
 fn test_set_validators() {

--- a/contracts/src/tests/isms/test_merkleroot_multisig.cairo
+++ b/contracts/src/tests/isms/test_merkleroot_multisig.cairo
@@ -5,16 +5,14 @@ use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERL
 use hyperlane_starknet::contracts::libs::multisig::merkleroot_ism_metadata::merkleroot_ism_metadata::MerkleRootIsmMetadata;
 use hyperlane_starknet::interfaces::IMessageRecipientDispatcherTrait;
 use hyperlane_starknet::interfaces::{
-    IMailboxDispatcher, IMailboxDispatcherTrait, ModuleType,
-    IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
-    IInterchainSecurityModule, IValidatorConfigurationDispatcher,
-    IValidatorConfigurationDispatcherTrait,
+    IMailboxDispatcher, IMailboxDispatcherTrait, ModuleType, IInterchainSecurityModuleDispatcher,
+    IInterchainSecurityModuleDispatcherTrait, IInterchainSecurityModule,
+    IValidatorConfigurationDispatcher, IValidatorConfigurationDispatcherTrait,
 };
 use hyperlane_starknet::tests::setup::{
     setup, setup_merkleroot_multisig_ism, OWNER, NEW_OWNER, VALIDATOR_ADDRESS_1,
-    VALIDATOR_ADDRESS_2, get_merkle_message_and_signature, LOCAL_DOMAIN,
-    DESTINATION_DOMAIN, TEST_PROOF, build_merkle_metadata, VALID_OWNER,
-    VALID_RECIPIENT
+    VALIDATOR_ADDRESS_2, get_merkle_message_and_signature, LOCAL_DOMAIN, DESTINATION_DOMAIN,
+    TEST_PROOF, build_merkle_metadata, VALID_OWNER, VALID_RECIPIENT
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};

--- a/contracts/src/tests/isms/test_messageid_multisig.cairo
+++ b/contracts/src/tests/isms/test_messageid_multisig.cairo
@@ -1,5 +1,4 @@
 use alexandria_bytes::{Bytes, BytesTrait};
-use alexandria_data_structures::array_ext::ArrayTraitExt;
 use core::array::ArrayTrait;
 use core::array::SpanTrait;
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERLANE_VERSION};
@@ -13,18 +12,15 @@ use hyperlane_starknet::interfaces::{
     IValidatorConfigurationDispatcherTrait,
 };
 use hyperlane_starknet::tests::setup::{
-    setup, mock_setup, setup_messageid_multisig_ism, OWNER, NEW_OWNER, VALIDATOR_ADDRESS_1,
-    VALIDATOR_ADDRESS_2, setup_validator_announce, get_message_and_signature, LOCAL_DOMAIN,
+    setup, setup_messageid_multisig_ism, OWNER, NEW_OWNER, VALIDATOR_ADDRESS_1,
+    VALIDATOR_ADDRESS_2, get_message_and_signature, LOCAL_DOMAIN,
     DESTINATION_DOMAIN, RECIPIENT_ADDRESS, build_messageid_metadata, VALID_OWNER, VALID_RECIPIENT
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::cheatcodes::events::EventAssertions;
-use snforge_std::{start_prank, CheatTarget, stop_prank};
-use starknet::eth_address::EthAddress;
-use starknet::eth_signature::verify_eth_signature;
-use starknet::secp256_trait::Signature;
-use starknet::secp256_trait::signature_from_vrs;
+use snforge_std::{start_prank, CheatTarget};
+
 #[test]
 fn test_set_validators() {
     let new_validators = array![VALIDATOR_ADDRESS_1(), VALIDATOR_ADDRESS_2()].span();

--- a/contracts/src/tests/isms/test_messageid_multisig.cairo
+++ b/contracts/src/tests/isms/test_messageid_multisig.cairo
@@ -12,9 +12,9 @@ use hyperlane_starknet::interfaces::{
     IValidatorConfigurationDispatcherTrait,
 };
 use hyperlane_starknet::tests::setup::{
-    setup, setup_messageid_multisig_ism, OWNER, NEW_OWNER, VALIDATOR_ADDRESS_1,
-    VALIDATOR_ADDRESS_2, get_message_and_signature, LOCAL_DOMAIN,
-    DESTINATION_DOMAIN, RECIPIENT_ADDRESS, build_messageid_metadata, VALID_OWNER, VALID_RECIPIENT
+    setup, setup_messageid_multisig_ism, OWNER, NEW_OWNER, VALIDATOR_ADDRESS_1, VALIDATOR_ADDRESS_2,
+    get_message_and_signature, LOCAL_DOMAIN, DESTINATION_DOMAIN, RECIPIENT_ADDRESS,
+    build_messageid_metadata, VALID_OWNER, VALID_RECIPIENT
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};

--- a/contracts/src/tests/routing/test_default_fallback_routing_ism.cairo
+++ b/contracts/src/tests/routing/test_default_fallback_routing_ism.cairo
@@ -9,11 +9,11 @@ use hyperlane_starknet::interfaces::{
 };
 use hyperlane_starknet::tests::setup::{
     OWNER, setup_default_fallback_routing_ism, build_messageid_metadata, LOCAL_DOMAIN, VALID_OWNER,
-    VALID_RECIPIENT, DESTINATION_DOMAIN, RECIPIENT_ADDRESS, setup_messageid_multisig_ism,
-    get_message_and_signature, setup_mailbox_client, setup
+    VALID_RECIPIENT, DESTINATION_DOMAIN, setup_messageid_multisig_ism,
+    get_message_and_signature, setup
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use snforge_std::{start_prank, CheatTarget, stop_prank, ContractClassTrait, declare};
+use snforge_std::{start_prank, CheatTarget, ContractClassTrait, declare};
 use starknet::{ContractAddress, contract_address_const};
 
 #[test]

--- a/contracts/src/tests/routing/test_default_fallback_routing_ism.cairo
+++ b/contracts/src/tests/routing/test_default_fallback_routing_ism.cairo
@@ -9,8 +9,8 @@ use hyperlane_starknet::interfaces::{
 };
 use hyperlane_starknet::tests::setup::{
     OWNER, setup_default_fallback_routing_ism, build_messageid_metadata, LOCAL_DOMAIN, VALID_OWNER,
-    VALID_RECIPIENT, DESTINATION_DOMAIN, setup_messageid_multisig_ism,
-    get_message_and_signature, setup
+    VALID_RECIPIENT, DESTINATION_DOMAIN, setup_messageid_multisig_ism, get_message_and_signature,
+    setup
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::{start_prank, CheatTarget, ContractClassTrait, declare};

--- a/contracts/src/tests/routing/test_domain_routing_ism.cairo
+++ b/contracts/src/tests/routing/test_domain_routing_ism.cairo
@@ -8,8 +8,9 @@ use hyperlane_starknet::interfaces::{
     IMailboxDispatcher, IMailboxDispatcherTrait
 };
 use hyperlane_starknet::tests::setup::{
-    OWNER, setup_domain_routing_ism, build_messageid_metadata, LOCAL_DOMAIN, DESTINATION_DOMAIN, setup_messageid_multisig_ism, get_message_and_signature,
-    setup_mailbox_client, VALID_OWNER, VALID_RECIPIENT
+    OWNER, setup_domain_routing_ism, build_messageid_metadata, LOCAL_DOMAIN, DESTINATION_DOMAIN,
+    setup_messageid_multisig_ism, get_message_and_signature, setup_mailbox_client, VALID_OWNER,
+    VALID_RECIPIENT
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::{start_prank, CheatTarget, stop_prank, ContractClassTrait};

--- a/contracts/src/tests/routing/test_domain_routing_ism.cairo
+++ b/contracts/src/tests/routing/test_domain_routing_ism.cairo
@@ -8,12 +8,11 @@ use hyperlane_starknet::interfaces::{
     IMailboxDispatcher, IMailboxDispatcherTrait
 };
 use hyperlane_starknet::tests::setup::{
-    OWNER, setup_domain_routing_ism, build_messageid_metadata, LOCAL_DOMAIN, DESTINATION_DOMAIN,
-    RECIPIENT_ADDRESS, setup_messageid_multisig_ism, get_message_and_signature,
+    OWNER, setup_domain_routing_ism, build_messageid_metadata, LOCAL_DOMAIN, DESTINATION_DOMAIN, setup_messageid_multisig_ism, get_message_and_signature,
     setup_mailbox_client, VALID_OWNER, VALID_RECIPIENT
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use snforge_std::{start_prank, CheatTarget, stop_prank, ContractClassTrait, declare};
+use snforge_std::{start_prank, CheatTarget, stop_prank, ContractClassTrait};
 use starknet::{ContractAddress, contract_address_const};
 
 #[test]

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -1,6 +1,4 @@
 use alexandria_bytes::{Bytes, BytesTrait};
-use alexandria_data_structures::array_ext::ArrayTraitExt;
-use core::result::ResultTrait;
 use hyperlane_starknet::contracts::libs::multisig::merkleroot_ism_metadata::merkleroot_ism_metadata::MERKLE_PROOF_ITERATION;
 use hyperlane_starknet::interfaces::{
     IMailboxDispatcher, IMailboxDispatcherTrait, IMessageRecipientDispatcher,
@@ -8,8 +6,7 @@ use hyperlane_starknet::interfaces::{
     IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
     IValidatorAnnounceDispatcher, IValidatorAnnounceDispatcherTrait, IMailboxClientDispatcher,
     IMailboxClientDispatcherTrait, IAggregationDispatcher, IAggregationDispatcherTrait,
-    IValidatorConfigurationDispatcher, IMerkleTreeHookDispatcher, IMerkleTreeHookDispatcherTrait,
-    IAggregation, IPostDispatchHookDispatcher, IProtocolFeeDispatcher,
+    IValidatorConfigurationDispatcher, IMerkleTreeHookDispatcher, IMerkleTreeHookDispatcherTrait, IPostDispatchHookDispatcher, IProtocolFeeDispatcher,
     IPostDispatchHookDispatcherTrait, IProtocolFeeDispatcherTrait, IMockValidatorAnnounceDispatcher,
     ISpecifiesInterchainSecurityModuleDispatcher, ISpecifiesInterchainSecurityModuleDispatcherTrait,
     IRoutingIsmDispatcher, IRoutingIsmDispatcherTrait, IDomainRoutingIsmDispatcher,
@@ -20,9 +17,6 @@ use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20Disp
 use snforge_std::{
     declare, ContractClassTrait, CheatTarget, EventSpy, EventAssertions, spy_events, SpyOn
 };
-use starknet::secp256_trait::Signature;
-
-
 use starknet::{ContractAddress, contract_address_const, EthAddress};
 
 pub const LOCAL_DOMAIN: u32 = 534352;

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -336,13 +336,13 @@ pub fn build_messageid_metadata(origin_merkle_tree_hook: u256, root: u256, index
 
 // Configuration from the main cairo repo: https://github.com/starkware-libs/cairo/blob/main/corelib/src/test/secp256k1_test.cairo
 pub fn get_message_and_signature() -> (u256, Array<EthAddress>, Array<EthSignature>) {
-    let msg_hash = 0xFDE2D5B5D42F48CA195ED90A8F4E826C786B7DCDCFA19F5A26048C93DD3044D2;
+    let msg_hash = 0xEBC2F3E10A13E54662AB9B1ABB83E954EA31E5622AF8239EB97D22CC351324D2;
     let validators_array: Array<EthAddress> = array![
-        0xdb5278a58bf0651ed0bb6201563d2d2fed583849.try_into().unwrap(),
-        0x0952f3030332b6a06dec9cd4b18528f7e20bcf7a.try_into().unwrap(),
-        0x8bbaa43abd2ecfbd8c8affd5198b745071d5fd51.try_into().unwrap(),
-        0xaa9d9ab3a9380a05aa6a671d0de15f29772fd476.try_into().unwrap(),
-        0x8f27d34c9a110acf55d12005f4af4318b4073881.try_into().unwrap()
+        0x8a719a6529c8fdef4df79079f47ae74fd4037b08.try_into().unwrap(),
+        0xb93289817c013182bf7f7d1e2e4577a77d4be7d7.try_into().unwrap(),
+        0x92316e3bacc840258925ba3eba801aaae5347a09.try_into().unwrap(),
+        0xef7cc63f461666cb47688a9c3975504341e2e12b.try_into().unwrap(),
+        0x3ba6645137a79068c4e83ea6f97d35c2b3d1e3fb.try_into().unwrap()
     ];
     let signatures = array![
         EthSignature {
@@ -406,13 +406,13 @@ pub fn build_merkle_metadata(
 
 // Configuration from the main cairo repo: https://github.com/starkware-libs/cairo/blob/main/corelib/src/test/secp256k1_test.cairo
 pub fn get_merkle_message_and_signature() -> (u256, Array<EthAddress>, Array<EthSignature>) {
-    let msg_hash = 0xF741712B0DAF736A4AFCD98A32AB902E6269E50AA54789702738C2358C0260D6;
+    let msg_hash = 0x4B73BFF28F5521D6F2F38F344427CCF23DCE6BA26F96C4EB14C1656348F4D153;
     let validators_array: Array<EthAddress> = array![
-        0x607f328cf57d921b08d0be5da6a094f6031773d9.try_into().unwrap(),
-        0x308fca3c679010f692fb30837aa7ffb744039ea1.try_into().unwrap(),
-        0x48f7ee4a727188621600948c5c1995b28899d3b5.try_into().unwrap(),
-        0x66d7205a8336b14e69c3d288c9931cb8995f280f.try_into().unwrap(),
-        0xa78ad18b57339ec6ac280b232c86217730734a9f.try_into().unwrap()
+        0xbce3b51b0d6ff506e23ddfd6789ac5a60a1103a4.try_into().unwrap(),
+        0xe0c60d0f83f70f5eb497bfc7a2315cb5ca88f801.try_into().unwrap(),
+        0x0dc578af77510a16da2a3557e822085a95df6962.try_into().unwrap(),
+        0x6593c1d433696640d90b76d804fdaa0e5277230f.try_into().unwrap(),
+        0x9350b8b7031e7df5e2f7b95697bc90d42357fa1f.try_into().unwrap()
     ];
     let signatures = array![
         EthSignature {

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -6,8 +6,9 @@ use hyperlane_starknet::interfaces::{
     IInterchainSecurityModuleDispatcher, IInterchainSecurityModuleDispatcherTrait,
     IValidatorAnnounceDispatcher, IValidatorAnnounceDispatcherTrait, IMailboxClientDispatcher,
     IMailboxClientDispatcherTrait, IAggregationDispatcher, IAggregationDispatcherTrait,
-    IValidatorConfigurationDispatcher, IMerkleTreeHookDispatcher, IMerkleTreeHookDispatcherTrait, IPostDispatchHookDispatcher, IProtocolFeeDispatcher,
-    IPostDispatchHookDispatcherTrait, IProtocolFeeDispatcherTrait, IMockValidatorAnnounceDispatcher,
+    IValidatorConfigurationDispatcher, IMerkleTreeHookDispatcher, IMerkleTreeHookDispatcherTrait,
+    IPostDispatchHookDispatcher, IProtocolFeeDispatcher, IPostDispatchHookDispatcherTrait,
+    IProtocolFeeDispatcherTrait, IMockValidatorAnnounceDispatcher,
     ISpecifiesInterchainSecurityModuleDispatcher, ISpecifiesInterchainSecurityModuleDispatcherTrait,
     IRoutingIsmDispatcher, IRoutingIsmDispatcherTrait, IDomainRoutingIsmDispatcher,
     IDomainRoutingIsmDispatcherTrait, IPausableIsmDispatcher, IPausableIsmDispatcherTrait

--- a/contracts/src/tests/test_mailbox.cairo
+++ b/contracts/src/tests/test_mailbox.cairo
@@ -4,9 +4,8 @@ use hyperlane_starknet::contracts::mailbox::mailbox;
 use hyperlane_starknet::interfaces::IMessageRecipientDispatcherTrait;
 use hyperlane_starknet::interfaces::{IMailbox, IMailboxDispatcher, IMailboxDispatcherTrait};
 use hyperlane_starknet::tests::setup::{
-    setup, mock_setup, OWNER, LOCAL_DOMAIN, NEW_OWNER, DEFAULT_ISM, DEFAULT_HOOK, REQUIRED_HOOK,
+    setup, mock_setup, OWNER, LOCAL_DOMAIN, NEW_OWNER, DEFAULT_ISM,
     NEW_DEFAULT_ISM, NEW_DEFAULT_HOOK, NEW_REQUIRED_HOOK, DESTINATION_DOMAIN, RECIPIENT_ADDRESS,
-    setup_mock_hook, setup_mock_ism
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};

--- a/contracts/src/tests/test_mailbox.cairo
+++ b/contracts/src/tests/test_mailbox.cairo
@@ -4,8 +4,8 @@ use hyperlane_starknet::contracts::mailbox::mailbox;
 use hyperlane_starknet::interfaces::IMessageRecipientDispatcherTrait;
 use hyperlane_starknet::interfaces::{IMailbox, IMailboxDispatcher, IMailboxDispatcherTrait};
 use hyperlane_starknet::tests::setup::{
-    setup, mock_setup, OWNER, LOCAL_DOMAIN, NEW_OWNER, DEFAULT_ISM,
-    NEW_DEFAULT_ISM, NEW_DEFAULT_HOOK, NEW_REQUIRED_HOOK, DESTINATION_DOMAIN, RECIPIENT_ADDRESS,
+    setup, mock_setup, OWNER, LOCAL_DOMAIN, NEW_OWNER, DEFAULT_ISM, NEW_DEFAULT_ISM,
+    NEW_DEFAULT_HOOK, NEW_REQUIRED_HOOK, DESTINATION_DOMAIN, RECIPIENT_ADDRESS,
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};

--- a/contracts/src/tests/test_validator_announce.cairo
+++ b/contracts/src/tests/test_validator_announce.cairo
@@ -1,5 +1,4 @@
 use alexandria_bytes::{Bytes, BytesTrait, BytesIndex};
-use alexandria_data_structures::array_ext::ArrayTraitExt;
 use hyperlane_starknet::contracts::isms::multisig::validator_announce::validator_announce;
 use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::{HYPERLANE_ANNOUNCEMENT};
 use hyperlane_starknet::interfaces::{
@@ -8,7 +7,7 @@ use hyperlane_starknet::interfaces::{
 };
 use hyperlane_starknet::tests::setup::{setup_mock_validator_announce, setup_validator_announce};
 use snforge_std::cheatcodes::events::EventAssertions;
-use starknet::{ContractAddress, contract_address_const, EthAddress};
+use starknet::{contract_address_const, EthAddress};
 
 pub const TEST_STARKNET_DOMAIN: u32 = 23448593;
 

--- a/contracts/src/utils/keccak256.cairo
+++ b/contracts/src/utils/keccak256.cairo
@@ -3,6 +3,10 @@ use core::integer::u128_byte_reverse;
 use core::keccak::cairo_keccak;
 use core::to_byte_array::{FormatAsByteArray, AppendFormattedToByteArray};
 use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::{HYPERLANE_ANNOUNCEMENT};
+use starknet::{ EthAddress, eth_signature::is_eth_signature_valid,
+    secp256_trait::Signature
+};
+
 pub const ETH_SIGNED_MESSAGE: felt252 = '\x19Ethereum Signed Message:\n32';
 
 
@@ -62,6 +66,23 @@ pub fn to_eth_signature(hash: u256) -> u256 {
     reverse_endianness(hash)
 }
 
+/// Determines the correctness of an ethereum signature given a digest, signer and signature 
+/// 
+/// # Arguments 
+/// 
+/// * - `_msg_hash` - to digest used to sign the message
+/// * - `_signature` - the signature to check
+/// * - `_signer` - the signer ethereum address
+/// 
+/// # Returns 
+/// 
+/// boolean - True if valid
+pub fn bool_is_eth_signature_valid(msg_hash: u256, signature: Signature, signer: EthAddress) -> bool {
+    match is_eth_signature_valid(msg_hash, signature, signer) {
+        Result::Ok(()) => true,
+        Result::Err(_) => false
+    }
+}
 
 /// Reverse an u64 word (little_endian <-> big endian)
 /// For example 0x12345678 will return 0x78563412

--- a/contracts/src/utils/keccak256.cairo
+++ b/contracts/src/utils/keccak256.cairo
@@ -2,10 +2,8 @@ use core::byte_array::{ByteArray, ByteArrayTrait};
 use core::integer::u128_byte_reverse;
 use core::keccak::cairo_keccak;
 use core::to_byte_array::{FormatAsByteArray, AppendFormattedToByteArray};
-use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::{HYPERLANE_ANNOUNCEMENT};
-use starknet::{ EthAddress, eth_signature::is_eth_signature_valid,
-    secp256_trait::Signature
-};
+use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::HYPERLANE_ANNOUNCEMENT;
+use starknet::{EthAddress, eth_signature::is_eth_signature_valid, secp256_trait::Signature};
 
 pub const ETH_SIGNED_MESSAGE: felt252 = '\x19Ethereum Signed Message:\n32';
 
@@ -31,7 +29,7 @@ pub struct ByteData {
 }
 
 
-/// Reverse the endianness of an u256
+/// Reverses the endianness of an u256
 /// 
 /// # Arguments
 /// 
@@ -47,7 +45,7 @@ pub fn reverse_endianness(value: u256) -> u256 {
 }
 
 
-/// Determine the Ethereum compatible signature for a given hash
+/// Determines the Ethereum compatible signature for a given hash
 /// dev : Since call this function for hash only, the ETH_SIGNED_MESSAGE size will always be 32
 /// 
 ///  # Arguments
@@ -77,14 +75,16 @@ pub fn to_eth_signature(hash: u256) -> u256 {
 /// # Returns 
 /// 
 /// boolean - True if valid
-pub fn bool_is_eth_signature_valid(msg_hash: u256, signature: Signature, signer: EthAddress) -> bool {
+pub fn bool_is_eth_signature_valid(
+    msg_hash: u256, signature: Signature, signer: EthAddress
+) -> bool {
     match is_eth_signature_valid(msg_hash, signature, signer) {
         Result::Ok(()) => true,
         Result::Err(_) => false
     }
 }
 
-/// Reverse an u64 word (little_endian <-> big endian)
+/// Reverses an u64 word (little_endian <-> big endian)
 /// For example 0x12345678 will return 0x78563412
 /// For this function, we used an existing function of the cairo lib `u128_byte_reverse`
 /// 
@@ -137,7 +137,7 @@ fn keccak_cairo_words64(words: Words64, last_word_bytes: usize) -> u256 {
 }
 
 
-/// Determine the size of a u64 element, by successive division 
+/// Determines the size of a u64 element, by successive division 
 ///
 /// # Arguments
 /// 
@@ -158,7 +158,7 @@ pub fn u64_word_size(word: u64) -> u8 {
 }
 
 
-/// Determine the size of a u256 element, by successive division 
+/// Determines the size of a u256 element, by successive division 
 ///
 /// # Arguments
 /// 
@@ -178,7 +178,7 @@ pub fn u256_word_size(word: u256) -> u8 {
     word_len
 }
 
-/// Build an u64 span out of a concatenated string (ByteArray)
+/// Builds an u64 span out of a concatenated string (ByteArray)
 /// dev: ByteArray is in fact a array of Bytes31 (u8) 
 /// 
 /// # Argument
@@ -220,7 +220,7 @@ fn build_u64_array(bytes: @ByteArray) -> Span<u64> {
 }
 
 
-/// Shift helper for u64
+/// Shifts helper for u64
 /// dev : panics if u64 overflow
 /// 
 /// # Arguments
@@ -244,7 +244,7 @@ pub fn one_shift_left_bytes_u64(n_bytes: u8) -> u64 {
     }
 }
 
-/// Retrieve the two last words (u64) for a given string (ByteArray)
+/// Retrieves the two last words (u64) for a given string (ByteArray)
 /// 
 /// # Arguments
 /// * `word` - a snapshot of the string to consider 
@@ -277,7 +277,7 @@ fn get_two_last_words(word: @ByteArray, last_word_len: u8) -> u128 {
 }
 
 
-/// Shift helper for u256
+/// Shifts helper for u256
 /// dev : panics if u256 overflow
 /// 
 /// # Arguments
@@ -326,7 +326,7 @@ pub fn one_shift_left_bytes_u256(n_bytes: u8) -> u256 {
 }
 
 
-/// Reverse an u64 word. If a padding is provided, shift the result with the padding. 
+/// Reverses an u64 word. If a padding is provided, shift the result with the padding. 
 /// 
 /// # Arguments
 /// 
@@ -364,7 +364,7 @@ fn reverse_u64_word(words: Span<u64>, padding: u8) -> Span<u64> {
     reverse_u64.span()
 }
 
-/// Given a span of ByteData, returns a concatenated string (ByteArray) of the input
+/// Givens a span of ByteData, returns a concatenated string (ByteArray) of the input
 /// 
 /// # Arguments
 /// 


### PR DESCRIPTION
## Message formatting 

According to the solidity implementation (cf: https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/libs/Message.sol), abi.encode is used to format the message and generate the id. In our case, we hashed the elements of the Message structure in order to have a storable u256, using `compute_keccak`.  However, when calling this function we need to make sure to reverse the endianness afterwards further errors ( notably for example when using this id to compute other hash). This pull request fixes this issue. 

## Breaking changes

No significant breaking changes, but since the message hashing output is different, the computed digest will be different, and hardcoded hash values in tests needed to be adjusted accordingly 