### PR TITLE
Feat hyperlane contract feedback corrections

### DIFF
--- a/contracts/src/contracts/client/mailboxclient.cairo
+++ b/contracts/src/contracts/client/mailboxclient.cairo
@@ -1,5 +1,5 @@
 #[starknet::contract]
-mod mailboxclient {
+mod mailboxClientProxy {
     use hyperlane_starknet::contracts::client::mailboxclient_component::{
         MailboxclientComponent, MailboxclientComponent::MailboxClientInternalImpl
     };

--- a/contracts/src/contracts/client/mailboxclient_component.cairo
+++ b/contracts/src/contracts/client/mailboxclient_component.cairo
@@ -146,6 +146,7 @@ pub mod MailboxclientComponent {
         /// * - `_destination_domain` Domain of destination chain
         /// * - `_recipient` Address of recipient on destination chain
         /// * - `_message_body` Bytes content of message body
+        /// * - `_fee_amount` - the payment provided for sending the message
         /// * - `_hook_metadata` Metadata used by the post dispatch hook
         /// * - `_hook` Custom hook to use instead of the default
         /// 
@@ -157,13 +158,21 @@ pub mod MailboxclientComponent {
             _destination_domain: u32,
             _recipient: ContractAddress,
             _message_body: Bytes,
+            _fee_amount: u256,
             _hook_metadata: Option<Bytes>,
             _hook: Option<ContractAddress>
         ) -> u256 {
             self
                 .mailbox
                 .read()
-                .dispatch(_destination_domain, _recipient, _message_body, _hook_metadata, _hook)
+                .dispatch(
+                    _destination_domain,
+                    _recipient,
+                    _message_body,
+                    _fee_amount,
+                    _hook_metadata,
+                    _hook
+                )
         }
 
         /// Computes quote for dispatching a message to the destination domain & recipient.
@@ -198,9 +207,7 @@ pub mod MailboxclientComponent {
 
     #[generate_trait]
     pub impl MailboxClientInternalImpl<
-        TContractState,
-        +HasComponent<TContractState>,
-        impl Owner: OwnableComponent::HasComponent<TContractState>
+        TContractState, +HasComponent<TContractState>,
     > of InternalTrait<TContractState> {
         /// Initializes the mailbox client configuration.
         /// Dev: callable on constructor

--- a/contracts/src/contracts/hooks/merkle_tree_hook.cairo
+++ b/contracts/src/contracts/hooks/merkle_tree_hook.cairo
@@ -127,7 +127,9 @@ pub mod merkle_tree_hook {
         /// * - `_metadata` - the metadata required for the hook
         /// * - `_message` - the message passed from the Mailbox.dispatch() call
         /// * - `_fee_amount` - the payment provided for sending the message
-       fn post_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256) {
+        fn post_dispatch(
+            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256
+        ) {
             assert(self.supports_metadata(_metadata.clone()), Errors::INVALID_METADATA_VARIANT);
             self._post_dispatch(_metadata, _message, _fee_amount);
         }
@@ -151,7 +153,9 @@ pub mod merkle_tree_hook {
 
     #[generate_trait]
     pub impl MerkleInternalImpl of InternalTrait {
-        fn _post_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256) {
+        fn _post_dispatch(
+            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256
+        ) {
             let (id, _) = MessageTrait::format_message(_message);
             // ensure messages which were not dispatched are not inserted into the tree
             assert(self.mailboxclient._is_latest_dispatched(id), Errors::MESSAGE_NOT_DISPATCHING);

--- a/contracts/src/contracts/hooks/protocol_fee.cairo
+++ b/contracts/src/contracts/hooks/protocol_fee.cairo
@@ -2,10 +2,10 @@
 pub mod protocol_fee {
     use alexandria_bytes::{Bytes, BytesTrait};
     use hyperlane_starknet::contracts::hooks::libs::standard_hook_metadata::standard_hook_metadata::{
-        StandardHookMetadata, VARIANT
+        StandardHookMetadata, VARIANT,
     };
     use hyperlane_starknet::contracts::libs::message::Message;
-    use hyperlane_starknet::interfaces::{IPostDispatchHook, Types, IProtocolFee};
+    use hyperlane_starknet::interfaces::{IPostDispatchHook, Types, IProtocolFee, ETH_ADDRESS};
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
@@ -33,6 +33,7 @@ pub mod protocol_fee {
         pub const EXCEEDS_MAX_PROTOCOL_FEE: felt252 = 'Exceeds max protocol fee';
         pub const INSUFFICIENT_BALANCE: felt252 = 'Insufficient balance';
         pub const INSUFFICIENT_ALLOWANCE: felt252 = 'Insufficient allowance';
+        pub const INSUFFICIENT_PROTOCOL_FEE: felt252 = 'Insufficient protocol fee';
     }
 
     #[event]
@@ -92,9 +93,12 @@ pub mod protocol_fee {
         /// 
         /// * - `_metadata` - the metadata required for the hook
         /// * - `_message` - the message passed from the Mailbox.dispatch() call
-        fn post_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) {
+        /// * - `_fee_amount` - the payment provided for sending the message
+        fn post_dispatch(
+            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256
+        ) {
             assert(self.supports_metadata(_metadata.clone()), Errors::INVALID_METADATA_VARIANT);
-            self._post_dispatch(_metadata, _message);
+            self._post_dispatch(_metadata, _message, _fee_amount);
         }
 
         ///  Computes the payment required by the postDispatch call
@@ -158,25 +162,16 @@ pub mod protocol_fee {
 
     #[generate_trait]
     impl InternalImpl of InternalTrait {
-        /// Post action after a message is dispatched via the Mailbox
-        /// Dev: revert if insufficient balance or allowance
+        /// Post action after a message is dispatched via the Mailbox (in our case, nothing because the )
         /// 
         /// # Arguments
         /// 
         /// * - `_metadata` - the metadata required for the hook
         /// * - `_message` - the message passed from the Mailbox.dispatch() call
-        fn _post_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) {
-            let token_dispatcher = IERC20Dispatcher { contract_address: self.fee_token.read() };
-            let caller_address = get_caller_address();
-            let contract_address = get_contract_address();
-            let user_balance = token_dispatcher.balance_of(caller_address);
-            assert(user_balance != 0, Errors::INSUFFICIENT_BALANCE);
-            let protocol_fee = self.protocol_fee.read();
-            assert(
-                token_dispatcher.allowance(caller_address, contract_address) >= protocol_fee,
-                Errors::INSUFFICIENT_ALLOWANCE
-            );
-            token_dispatcher.transfer_from(caller_address, contract_address, protocol_fee);
+        /// * - `_fee_amount` - the payment provided for sending the message
+        fn _post_dispatch(
+            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256
+        ) {// Since payment is exact, no need for further operation
         }
 
         ///  Returns the static protocol fee 

--- a/contracts/src/contracts/hooks/protocol_fee.cairo
+++ b/contracts/src/contracts/hooks/protocol_fee.cairo
@@ -9,9 +9,7 @@ pub mod protocol_fee {
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
-    use starknet::{
-        ContractAddress, contract_address_const, get_contract_address
-    };
+    use starknet::{ContractAddress, contract_address_const, get_contract_address};
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     #[abi(embed_v0)]
     impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;

--- a/contracts/src/contracts/hooks/protocol_fee.cairo
+++ b/contracts/src/contracts/hooks/protocol_fee.cairo
@@ -171,7 +171,7 @@ pub mod protocol_fee {
         /// * - `_fee_amount` - the payment provided for sending the message
         fn _post_dispatch(
             ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256
-        ) {// Since payment is exact, no need for further operation
+        ) { // Since payment is exact, no need for further operation
         }
 
         ///  Returns the static protocol fee 

--- a/contracts/src/contracts/hooks/protocol_fee.cairo
+++ b/contracts/src/contracts/hooks/protocol_fee.cairo
@@ -10,7 +10,7 @@ pub mod protocol_fee {
     use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
     use starknet::{
-        ContractAddress, contract_address_const, get_caller_address, get_contract_address
+        ContractAddress, contract_address_const, get_contract_address
     };
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     #[abi(embed_v0)]

--- a/contracts/src/contracts/isms/aggregation/aggregation.cairo
+++ b/contracts/src/contracts/isms/aggregation/aggregation.cairo
@@ -169,21 +169,6 @@ pub mod aggregation {
                 last_module = module;
             }
         }
-        /// Helper:  finds the last module stored in the legacy map
-        /// 
-        /// # Returns
-        /// 
-        /// ContractAddress -the address of the last module stored. 
-        fn find_last_module(self: @ContractState) -> ContractAddress {
-            let mut current_module = self.modules.read(contract_address_const::<0>());
-            loop {
-                let next_module = self.modules.read(current_module);
-                if next_module == contract_address_const::<0>() {
-                    break current_module;
-                }
-                current_module = next_module;
-            }
-        }
         /// Helper:  finds the index associated to a module in the legacy map
         /// 
         /// # Returns
@@ -202,26 +187,6 @@ pub mod aggregation {
                 }
                 current_module = next_module;
             }
-        }
-
-        /// Helper:  determines if a span of modules are already stored in the Storage Mapping
-        /// 
-        /// # Returns
-        /// 
-        /// boolean - True if at least one module is stored
-        fn are_modules_stored(self: @ContractState, _modules: Span<ContractAddress>) -> bool {
-            let mut cur_idx = 0;
-            let mut result = false;
-            while cur_idx < _modules.len()
-                && result == false {
-                    let module = *_modules.at(cur_idx);
-                    match self.find_module_index(module) {
-                        Option::Some => result = true,
-                        Option::None => {}
-                    };
-                    cur_idx += 1;
-                };
-            result
         }
 
         /// Helper:  Build a module span out of a storage map

--- a/contracts/src/contracts/isms/aggregation/aggregation.cairo
+++ b/contracts/src/contracts/isms/aggregation/aggregation.cairo
@@ -45,13 +45,14 @@ pub mod aggregation {
         pub const MODULE_ADDRESS_CANNOT_BE_NULL: felt252 = 'Module address cannot be null';
         pub const THRESHOLD_NOT_SET: felt252 = 'Threshold not set';
         pub const MODULES_ALREADY_STORED: felt252 = 'Modules already stored';
+        pub const NO_MODULES_PROVIDED: felt252 = 'No modules provided';
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, _owner: ContractAddress) {
+    fn constructor(ref self: ContractState, _owner: ContractAddress, _modules: Span<felt252>) {
         self.ownable.initializer(_owner);
+        self.set_modules(_modules);
     }
-
 
     #[abi(embed_v0)]
     impl IAggregationImpl of IAggregation<ContractState> {
@@ -130,33 +131,6 @@ pub mod aggregation {
             self.threshold.read()
         }
 
-        /// Sets the ISM modules responsible for the verification
-        /// Dev: reverts if module address is null
-        /// Dev: Callable only by the owner
-        /// 
-        /// # Arguments
-        /// 
-        /// * - `_modules` - a span of module contract addresses
-        /// 
-        fn set_modules(ref self: ContractState, _modules: Span<ContractAddress>) {
-            self.ownable.assert_only_owner();
-            assert(!self.are_modules_stored(_modules), Errors::MODULES_ALREADY_STORED);
-            let mut last_module = self.find_last_module();
-            let mut cur_idx = 0;
-            loop {
-                if (cur_idx == _modules.len()) {
-                    break ();
-                }
-                let module = *_modules.at(cur_idx);
-                assert(
-                    module != contract_address_const::<0>(), Errors::MODULE_ADDRESS_CANNOT_BE_NULL
-                );
-                self.modules.write(last_module, module);
-                cur_idx += 1;
-                last_module = module;
-            }
-        }
-
         /// Sets the threshold for validation
         /// Dev: callable only by the owner
         /// 
@@ -170,6 +144,31 @@ pub mod aggregation {
     }
     #[generate_trait]
     impl InternalImpl of InternalTrait {
+        /// Sets the ISM modules responsible for the verification
+        /// Dev: reverts if module address is null or if empty array
+        /// Dev: Callable only once during initialization
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_modules` - a span of module contract addresses
+        /// 
+        fn set_modules(ref self: ContractState, _modules: Span<felt252>) {
+            assert(_modules.len() != 0, Errors::NO_MODULES_PROVIDED);
+            let mut last_module = contract_address_const::<0>();
+            let mut cur_idx = 0;
+            loop {
+                if (cur_idx == _modules.len()) {
+                    break ();
+                }
+                let module: ContractAddress = (*_modules.at(cur_idx)).try_into().unwrap();
+                assert(
+                    module != contract_address_const::<0>(), Errors::MODULE_ADDRESS_CANNOT_BE_NULL
+                );
+                self.modules.write(last_module, module);
+                cur_idx += 1;
+                last_module = module;
+            }
+        }
         /// Helper:  finds the last module stored in the legacy map
         /// 
         /// # Returns

--- a/contracts/src/contracts/isms/multisig/messageid_multisig_ism.cairo
+++ b/contracts/src/contracts/isms/multisig/messageid_multisig_ism.cairo
@@ -35,6 +35,7 @@ pub mod messageid_multisig_ism {
         pub const NO_MATCH_FOR_SIGNATURE: felt252 = 'No match for given signature';
         pub const EMPTY_METADATA: felt252 = 'Empty metadata';
         pub const VALIDATOR_ADDRESS_CANNOT_BE_NULL: felt252 = 'Validator address cannot be 0';
+        pub const NO_VALIDATORS_PROVIDED: felt252 = 'No validators provided';
     }
 
     #[event]
@@ -48,8 +49,9 @@ pub mod messageid_multisig_ism {
 
 
     #[constructor]
-    fn constructor(ref self: ContractState, _owner: ContractAddress) {
+    fn constructor(ref self: ContractState, _owner: ContractAddress, _validators: Span<felt252>) {
         self.ownable.initializer(_owner);
+        self.set_validators(_validators);
     }
 
     #[abi(embed_v0)]
@@ -113,28 +115,6 @@ pub mod messageid_multisig_ism {
             self.threshold.read()
         }
 
-        /// Sets a span of validators responsible to verify the message
-        /// Dev: callable only by the admin
-        /// 
-        /// # Arguments 
-        ///
-        /// * - `_validators` - a span of validators to set
-        fn set_validators(ref self: ContractState, _validators: Span<EthAddress>) {
-            self.ownable.assert_only_owner();
-            let mut cur_idx = 0;
-
-            loop {
-                if (cur_idx == _validators.len()) {
-                    break ();
-                }
-                let validator = *_validators.at(cur_idx);
-                assert(
-                    validator != 0.try_into().unwrap(), Errors::VALIDATOR_ADDRESS_CANNOT_BE_NULL
-                );
-                self.validators.write(cur_idx.into(), validator);
-                cur_idx += 1;
-            }
-        }
 
         /// Set the threshold for validation
         /// Dev: callable only by the owner
@@ -220,6 +200,30 @@ pub mod messageid_multisig_ism {
                 cur_idx += 1;
             };
             validators.span()
+        }
+
+
+        /// Sets a span of validators responsible to verify the message
+        /// Dev: callable only during initialization
+        /// Dev: reverts if null validator address or empty span
+        /// 
+        /// # Arguments 
+        ///
+        /// * - `_validators` - a span of validators to set
+        fn set_validators(ref self: ContractState, _validators: Span<felt252>) {
+            assert(_validators.len() != 0, Errors::NO_VALIDATORS_PROVIDED);
+            let mut cur_idx = 0;
+            loop {
+                if (cur_idx == _validators.len()) {
+                    break ();
+                }
+                let validator: EthAddress = (*_validators.at(cur_idx)).try_into().unwrap();
+                assert(
+                    validator != 0.try_into().unwrap(), Errors::VALIDATOR_ADDRESS_CANNOT_BE_NULL
+                );
+                self.validators.write(cur_idx.into(), validator);
+                cur_idx += 1;
+            }
         }
     }
 }

--- a/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
@@ -58,7 +58,7 @@ pub mod aggregation_ism_metadata {
         /// boolean -  Whether or not metadata was provided for the ISM at `_index`
         fn has_metadata(_metadata: Bytes, _index: u8) -> bool {
             match metadata_range(_metadata, _index) {
-                Result::Ok((start, _)) => true,
+                Result::Ok((_, _)) => true,
                 Result::Err(_) => false
             }
         }

--- a/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
@@ -58,7 +58,7 @@ pub mod aggregation_ism_metadata {
         /// boolean -  Whether or not metadata was provided for the ISM at `_index`
         fn has_metadata(_metadata: Bytes, _index: u8) -> bool {
             match metadata_range(_metadata, _index) {
-                Result::Ok((start, _)) => { start > 0 },
+                Result::Ok((start, _)) => true,
                 Result::Err(_) => false
             }
         }

--- a/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
+++ b/contracts/src/contracts/libs/aggregation_ism_metadata.cairo
@@ -58,7 +58,7 @@ pub mod aggregation_ism_metadata {
         /// boolean -  Whether or not metadata was provided for the ISM at `_index`
         fn has_metadata(_metadata: Bytes, _index: u8) -> bool {
             match metadata_range(_metadata, _index) {
-                Result::Ok((_, _)) => true,
+                Result::Ok((start, _)) => { start > 0 },
                 Result::Err(_) => false
             }
         }

--- a/contracts/src/contracts/mocks/fee_hook.cairo
+++ b/contracts/src/contracts/mocks/fee_hook.cairo
@@ -1,0 +1,34 @@
+#[starknet::contract]
+pub mod fee_hook {
+    use alexandria_bytes::{Bytes, BytesTrait, BytesStore};
+    use hyperlane_starknet::contracts::libs::message::Message;
+    use hyperlane_starknet::interfaces::{
+        IPostDispatchHook, IPostDispatchHookDispatcher, IPostDispatchHookDispatcherTrait, Types
+    };
+    use starknet::ContractAddress;
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl IPostDispatchHookImpl of IPostDispatchHook<ContractState> {
+        fn hook_type(self: @ContractState) -> Types {
+            Types::UNUSED(())
+        }
+
+        fn supports_metadata(self: @ContractState, _metadata: Bytes) -> bool {
+            true
+        }
+
+        fn post_dispatch(
+            ref self: ContractState,
+            _metadata: Bytes,
+            _message: Message,
+            _fee_amount: u256,
+        ) {}
+
+        fn quote_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) -> u256 {
+            3000000
+        }
+    }
+}

--- a/contracts/src/contracts/mocks/fee_hook.cairo
+++ b/contracts/src/contracts/mocks/fee_hook.cairo
@@ -21,10 +21,7 @@ pub mod fee_hook {
         }
 
         fn post_dispatch(
-            ref self: ContractState,
-            _metadata: Bytes,
-            _message: Message,
-            _fee_amount: u256,
+            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256,
         ) {}
 
         fn quote_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) -> u256 {

--- a/contracts/src/contracts/mocks/hook.cairo
+++ b/contracts/src/contracts/mocks/hook.cairo
@@ -6,7 +6,6 @@ pub mod hook {
         IPostDispatchHook, IPostDispatchHookDispatcher, IPostDispatchHookDispatcherTrait, Types
     };
 
-
     #[storage]
     struct Storage {}
 
@@ -20,7 +19,9 @@ pub mod hook {
             true
         }
 
-        fn post_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) {}
+        fn post_dispatch(
+            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256
+        ) {}
 
         fn quote_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) -> u256 {
             0_u256

--- a/contracts/src/interfaces.cairo
+++ b/contracts/src/interfaces.cairo
@@ -5,6 +5,10 @@ use hyperlane_starknet::contracts::libs::message::Message;
 use starknet::ContractAddress;
 use starknet::EthAddress;
 
+pub fn ETH_ADDRESS() -> ContractAddress {
+    0x049D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7.try_into().unwrap()
+}
+
 #[derive(Serde, Drop, Debug, PartialEq)]
 pub enum Types {
     UNUSED,
@@ -55,6 +59,7 @@ pub trait IMailbox<TContractState> {
         _destination_domain: u32,
         _recipient_address: ContractAddress,
         _message_body: Bytes,
+        _fee_amount: u256,
         _custom_hook_metadata: Option<Bytes>,
         _custom_hook: Option<ContractAddress>,
     ) -> u256;
@@ -68,7 +73,7 @@ pub trait IMailbox<TContractState> {
         _custom_hook: Option<ContractAddress>,
     ) -> u256;
 
-    fn process(ref self: TContractState, _metadata: Bytes, _message: Message,);
+    fn process(ref self: TContractState, _metadata: Bytes, _message: Message);
 
     fn recipient_ism(self: @TContractState, _recipient: ContractAddress) -> ContractAddress;
 
@@ -78,8 +83,6 @@ pub trait IMailbox<TContractState> {
 
     fn set_required_hook(ref self: TContractState, _hook: ContractAddress);
 
-    fn set_local_domain(ref self: TContractState, _local_domain: u32);
-
     fn processor(self: @TContractState, _id: u256) -> ContractAddress;
 
     fn processed_at(self: @TContractState, _id: u256) -> u64;
@@ -88,17 +91,8 @@ pub trait IMailbox<TContractState> {
 
 #[starknet::interface]
 pub trait IInterchainSecurityModule<TContractState> {
-    /// Returns an enum that represents the type of security model encoded by this ISM.
-    /// Relayers infer how to fetch and format metadata.
     fn module_type(self: @TContractState) -> ModuleType;
 
-    /// Defines a security model responsible for verifying interchain messages based on the provided metadata.
-    /// Returns true if the message was verified.
-    /// 
-    /// # Arguments
-    /// * `_metadata` - Off-chain metadata provided by a relayer, specific to the security model encoded by 
-    /// the module (e.g. validator signatures)
-    /// * `_message` - Hyperlane encoded interchain message
     fn verify(self: @TContractState, _metadata: Bytes, _message: Message,) -> bool;
 }
 
@@ -111,8 +105,6 @@ pub trait IValidatorConfiguration<TContractState> {
     fn get_validators(self: @TContractState) -> Span<EthAddress>;
 
     fn get_threshold(self: @TContractState) -> u32;
-
-    fn set_validators(ref self: TContractState, _validators: Span<EthAddress>);
 
     fn set_threshold(ref self: TContractState, _threshold: u32);
 }
@@ -129,7 +121,9 @@ pub trait IPostDispatchHook<TContractState> {
 
     fn supports_metadata(self: @TContractState, _metadata: Bytes) -> bool;
 
-    fn post_dispatch(ref self: TContractState, _metadata: Bytes, _message: Message);
+    fn post_dispatch(
+        ref self: TContractState, _metadata: Bytes, _message: Message, _fee_amount: u256
+    );
 
     fn quote_dispatch(ref self: TContractState, _metadata: Bytes, _message: Message) -> u256;
 }
@@ -176,6 +170,7 @@ pub trait IMailboxClient<TContractState> {
         _destination_domain: u32,
         _recipient: ContractAddress,
         _message_body: Bytes,
+        _fee_amount: u256,
         _hook_metadata: Option<Bytes>,
         _hook: Option<ContractAddress>
     ) -> u256;
@@ -204,23 +199,6 @@ pub trait IInterchainGasPaymaster<TContractState> {
     fn quote_gas_payment(
         ref self: TContractState, _destination_domain: u32, _gas_amount: u256
     ) -> u256;
-}
-
-#[starknet::interface]
-pub trait IRouter<TContractState> {
-    fn routers(self: @TContractState, _domain: u32) -> ContractAddress;
-
-    fn unenroll_remote_router(ref self: TContractState, _domain: u32);
-
-    fn enroll_remote_router(ref self: TContractState, _domain: u32, _router: ContractAddress);
-
-    fn enroll_remote_routers(
-        ref self: TContractState, _domains: Span<u32>, _routers: Span<ContractAddress>
-    );
-
-    fn unenroll_remote_routers(ref self: TContractState, _domains: Span<u32>);
-
-    fn handle(self: @TContractState, _origin: u32, _sender: ContractAddress, _message: Message);
 }
 
 
@@ -298,8 +276,6 @@ pub trait IAggregation<TContractState> {
     fn get_modules(self: @TContractState) -> Span<ContractAddress>;
 
     fn get_threshold(self: @TContractState) -> u8;
-
-    fn set_modules(ref self: TContractState, _modules: Span<ContractAddress>);
 
     fn set_threshold(ref self: TContractState, _threshold: u8);
 }

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -23,6 +23,7 @@ mod contracts {
     }
     pub mod mocks {
         pub mod fee_token;
+        pub mod fee_hook;
         pub mod hook;
         pub mod ism;
         pub mod message_recipient;

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -22,8 +22,8 @@ mod contracts {
         pub mod mailboxclient_component;
     }
     pub mod mocks {
-        pub mod fee_token;
         pub mod fee_hook;
+        pub mod fee_token;
         pub mod hook;
         pub mod ism;
         pub mod message_recipient;

--- a/contracts/src/tests/hooks/test_merkle_tree_hook.cairo
+++ b/contracts/src/tests/hooks/test_merkle_tree_hook.cairo
@@ -7,8 +7,7 @@ use hyperlane_starknet::interfaces::{
     IMerkleTreeHookDispatcherTrait
 };
 use hyperlane_starknet::tests::setup::{
-    setup_merkle_tree_hook, setup, MAILBOX, LOCAL_DOMAIN, VALID_OWNER, VALID_RECIPIENT,
-    DESTINATION_DOMAIN
+    setup_merkle_tree_hook, MAILBOX, LOCAL_DOMAIN, VALID_OWNER, VALID_RECIPIENT, DESTINATION_DOMAIN
 };
 use hyperlane_starknet::utils::keccak256::{ByteData, HASH_SIZE};
 use merkle_tree_hook::{InternalTrait, treeContractMemberStateTrait, countContractMemberStateTrait};
@@ -46,6 +45,7 @@ fn test_post_dispatch() {
             DESTINATION_DOMAIN,
             VALID_RECIPIENT(),
             BytesTrait::new_empty(),
+            0,
             Option::None,
             Option::None
         );
@@ -65,7 +65,7 @@ fn test_post_dispatch() {
         recipient: VALID_RECIPIENT(),
         body: BytesTrait::new_empty(),
     };
-    post_dispatch_hook.post_dispatch(metadata, message);
+    post_dispatch_hook.post_dispatch(metadata, message, 0);
     let expected_event = merkle_tree_hook::Event::InsertedIntoTree(
         merkle_tree_hook::InsertedIntoTree { id: id, index: count.try_into().unwrap() }
     );
@@ -89,7 +89,7 @@ fn test_post_dispatch_fails_if_message_not_dispatching() {
         recipient: VALID_RECIPIENT(),
         body: BytesTrait::new_empty(),
     };
-    post_dispatch_hook.post_dispatch(metadata, message);
+    post_dispatch_hook.post_dispatch(metadata, message, 0);
 }
 #[test]
 #[should_panic(expected: ('Invalid metadata variant',))]
@@ -99,7 +99,7 @@ fn test_post_dispatch_fails_if_invalid_variant() {
     let variant = 2;
     metadata.append_u16(variant);
     let message = MessageTrait::default();
-    post_dispatch_hook.post_dispatch(metadata, message);
+    post_dispatch_hook.post_dispatch(metadata, message, 0);
 }
 
 #[test]

--- a/contracts/src/tests/hooks/test_protocol_fee.cairo
+++ b/contracts/src/tests/hooks/test_protocol_fee.cairo
@@ -2,10 +2,11 @@ use alexandria_bytes::{Bytes, BytesTrait};
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait};
 use hyperlane_starknet::interfaces::{
     Types, IProtocolFeeDispatcher, IProtocolFeeDispatcherTrait, IPostDispatchHookDispatcher,
-    IPostDispatchHookDispatcherTrait
+    IPostDispatchHookDispatcherTrait, ETH_ADDRESS
 };
 use hyperlane_starknet::tests::setup::{
-    setup_protocol_fee, OWNER, MAX_PROTOCOL_FEE, BENEFICIARY, PROTOCOL_FEE, INITIAL_SUPPLY
+    setup_protocol_fee, OWNER, MAX_PROTOCOL_FEE, BENEFICIARY, PROTOCOL_FEE, INITIAL_SUPPLY,
+    setup_mock_token
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -14,13 +15,13 @@ use snforge_std::{start_prank, CheatTarget, stop_prank};
 
 #[test]
 fn test_hook_type() {
-    let (_, _, protocol_fee) = setup_protocol_fee();
+    let (_, protocol_fee) = setup_protocol_fee();
     assert_eq!(protocol_fee.hook_type(), Types::PROTOCOL_FEE(()));
 }
 
 #[test]
 fn test_set_protocol_fee() {
-    let (_, protocol_fee, _) = setup_protocol_fee();
+    let (protocol_fee, _) = setup_protocol_fee();
     let ownable = IOwnableDispatcher { contract_address: protocol_fee.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     let new_protocol_fee = 20000;
@@ -32,7 +33,7 @@ fn test_set_protocol_fee() {
 #[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_set_protocol_fee_fails_if_not_owner() {
-    let (_, protocol_fee, _) = setup_protocol_fee();
+    let (protocol_fee, _) = setup_protocol_fee();
     let new_protocol_fee = 20000;
     protocol_fee.set_protocol_fee(new_protocol_fee);
 }
@@ -40,7 +41,7 @@ fn test_set_protocol_fee_fails_if_not_owner() {
 #[test]
 #[should_panic(expected: ('Exceeds max protocol fee',))]
 fn test_set_protocol_fee_fails_if_higher_than_max() {
-    let (_, protocol_fee, _) = setup_protocol_fee();
+    let (protocol_fee, _) = setup_protocol_fee();
     let ownable = IOwnableDispatcher { contract_address: protocol_fee.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     let new_protocol_fee = MAX_PROTOCOL_FEE + 1;
@@ -51,7 +52,7 @@ fn test_set_protocol_fee_fails_if_higher_than_max() {
 
 #[test]
 fn test_set_beneficiary() {
-    let (_, protocol_fee, _) = setup_protocol_fee();
+    let (protocol_fee, _) = setup_protocol_fee();
     let ownable = IOwnableDispatcher { contract_address: protocol_fee.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     let new_beneficiary = 'NEW_BENEFICIARY'.try_into().unwrap();
@@ -63,7 +64,7 @@ fn test_set_beneficiary() {
 #[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_set_beneficiary_fails_if_not_owner() {
-    let (_, protocol_fee, _) = setup_protocol_fee();
+    let (protocol_fee, _) = setup_protocol_fee();
     let new_beneficiary = 'NEW_BENEFICIARY'.try_into().unwrap();
     protocol_fee.set_beneficiary(new_beneficiary);
 }
@@ -71,7 +72,8 @@ fn test_set_beneficiary_fails_if_not_owner() {
 
 #[test]
 fn test_collect_protocol_fee() {
-    let (fee_token, protocol_fee, _) = setup_protocol_fee();
+    let fee_token = setup_mock_token();
+    let (protocol_fee, _) = setup_protocol_fee();
     let ownable = IOwnableDispatcher { contract_address: fee_token.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
 
@@ -88,7 +90,8 @@ fn test_collect_protocol_fee() {
 #[test]
 #[should_panic(expected: ('Insufficient balance',))]
 fn test_collect_protocol_fee_fails_if_insufficient_balance() {
-    let (_, protocol_fee, _) = setup_protocol_fee();
+    setup_mock_token();
+    let (protocol_fee, _) = setup_protocol_fee();
     protocol_fee.collect_protocol_fees();
 }
 
@@ -96,7 +99,7 @@ fn test_collect_protocol_fee_fails_if_insufficient_balance() {
 #[test]
 fn test_supports_metadata() {
     let mut metadata = BytesTrait::new_empty();
-    let (_, _, post_dispatch_hook) = setup_protocol_fee();
+    let (_, post_dispatch_hook) = setup_protocol_fee();
     assert_eq!(post_dispatch_hook.supports_metadata(metadata.clone()), true);
     let variant = 1;
     metadata.append_u16(variant);
@@ -108,31 +111,10 @@ fn test_supports_metadata() {
 
 
 #[test]
-fn test_post_dispatch() {
-    let (fee_token, protocol_fee, post_dispatch_hook) = setup_protocol_fee();
-    let mut metadata = BytesTrait::new_empty();
-    let variant = 1;
-    let message = MessageTrait::default();
-    metadata.append_u16(variant);
-
-    let ownable = IOwnableDispatcher { contract_address: fee_token.contract_address };
-    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-
-    fee_token.approve(protocol_fee.contract_address, PROTOCOL_FEE);
-
-    stop_prank(CheatTarget::One(ownable.contract_address));
-    let ownable = IOwnableDispatcher { contract_address: protocol_fee.contract_address };
-    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    post_dispatch_hook.post_dispatch(metadata, message);
-    assert_eq!(fee_token.balance_of(OWNER()), INITIAL_SUPPLY - PROTOCOL_FEE);
-    assert_eq!(fee_token.balance_of(protocol_fee.contract_address), PROTOCOL_FEE);
-}
-
-
-#[test]
 #[should_panic(expected: ('Invalid metadata variant',))]
 fn test_post_dispatch_fails_if_invalid_variant() {
-    let (fee_token, _, post_dispatch_hook) = setup_protocol_fee();
+    let fee_token = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    let (_, post_dispatch_hook) = setup_protocol_fee();
     let ownable = IOwnableDispatcher { contract_address: fee_token.contract_address };
     let mut metadata = BytesTrait::new_empty();
     let variant = 2;
@@ -141,13 +123,13 @@ fn test_post_dispatch_fails_if_invalid_variant() {
     stop_prank(CheatTarget::One(ownable.contract_address));
     let ownable = IOwnableDispatcher { contract_address: post_dispatch_hook.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    post_dispatch_hook.post_dispatch(metadata, message);
+    post_dispatch_hook.post_dispatch(metadata, message, PROTOCOL_FEE);
 }
 
 
 #[test]
 fn test_quote_dispatch() {
-    let (_, _, post_dispatch_hook) = setup_protocol_fee();
+    let (_, post_dispatch_hook) = setup_protocol_fee();
     let mut metadata = BytesTrait::new_empty();
     let variant = 1;
     let message = MessageTrait::default();
@@ -159,7 +141,7 @@ fn test_quote_dispatch() {
 #[test]
 #[should_panic(expected: ('Invalid metadata variant',))]
 fn test_quote_dispatch_fails_if_invalid_variant() {
-    let (_, _, post_dispatch_hook) = setup_protocol_fee();
+    let (_, post_dispatch_hook) = setup_protocol_fee();
     let mut metadata = BytesTrait::new_empty();
     let variant = 2;
     metadata.append_u16(variant);

--- a/contracts/src/tests/isms/test_aggregation.cairo
+++ b/contracts/src/tests/isms/test_aggregation.cairo
@@ -1,4 +1,5 @@
 use alexandria_bytes::{Bytes, BytesTrait};
+use hyperlane_starknet::contracts::isms::aggregation::aggregation;
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERLANE_VERSION};
 use hyperlane_starknet::interfaces::{
     ModuleType, IAggregationDispatcher, IAggregationDispatcherTrait,
@@ -7,8 +8,10 @@ use hyperlane_starknet::interfaces::{
 };
 use hyperlane_starknet::tests::setup::{
     setup_aggregation, OWNER, setup_messageid_multisig_ism, get_message_and_signature, LOCAL_DOMAIN,
-    DESTINATION_DOMAIN, build_messageid_metadata, VALID_OWNER, VALID_RECIPIENT, setup_noop_ism
+    DESTINATION_DOMAIN, build_messageid_metadata, VALID_OWNER, VALID_RECIPIENT, setup_noop_ism,
+    MODULES, CONTRACT_MODULES
 };
+
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::{start_prank, CheatTarget};
@@ -16,7 +19,7 @@ use starknet::ContractAddress;
 
 #[test]
 fn test_aggregation_module_type() {
-    let aggregation = setup_aggregation();
+    let aggregation = setup_aggregation(MODULES());
     assert(
         aggregation.module_type() == ModuleType::AGGREGATION(aggregation.contract_address),
         'Aggregation: Wrong module type'
@@ -26,7 +29,7 @@ fn test_aggregation_module_type() {
 #[test]
 fn test_aggregation_set_threshold() {
     let threshold = 3;
-    let aggregation = setup_aggregation();
+    let aggregation = setup_aggregation(MODULES());
     let ownable = IOwnableDispatcher { contract_address: aggregation.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     aggregation.set_threshold(threshold);
@@ -35,48 +38,28 @@ fn test_aggregation_set_threshold() {
 #[test]
 #[should_panic(expected: ('Threshold not set',))]
 fn test_aggregation_verify_fails_if_treshold_not_set() {
-    let aggregation = setup_aggregation();
+    let aggregation = setup_aggregation(MODULES());
     aggregation.verify(BytesTrait::new(42, array![]), MessageTrait::default());
 }
 
 #[test]
-fn test_set_modules() {
-    let aggregation = setup_aggregation();
-    let ownable = IOwnableDispatcher { contract_address: aggregation.contract_address };
-    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    let module_1: ContractAddress = 'module_1'.try_into().unwrap();
-    let module_2: ContractAddress = 'module_2'.try_into().unwrap();
-    aggregation.set_modules(array![module_1, module_2].span());
-    assert(aggregation.get_modules() == array![module_1, module_2].span(), 'set modules failed');
+#[should_panic]
+fn test_setup_aggregation_with_null_module_address() {
+    let modules: Span<felt252> = array![0, 'module_1'].span();
+    setup_aggregation(modules);
 }
 
 #[test]
-#[should_panic(expected: ('Modules already stored',))]
-fn test_set_modules_fails_if_already_added_module() {
-    let aggregation = setup_aggregation();
+fn test_get_modules() {
+    let aggregation = setup_aggregation(MODULES());
     let ownable = IOwnableDispatcher { contract_address: aggregation.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    let module_1: ContractAddress = 'module_1'.try_into().unwrap();
-    let module_2: ContractAddress = 'module_2'.try_into().unwrap();
-    aggregation.set_modules(array![module_1, module_2].span());
-    assert(aggregation.get_modules() == array![module_1, module_2].span(), 'set modules failed');
-    aggregation.set_modules(array![module_1].span());
+    assert(aggregation.get_modules() == CONTRACT_MODULES(), 'set modules failed');
 }
 
-
-#[test]
-#[should_panic(expected: ('Caller is not the owner',))]
-fn test_set_module_fails_if_caller_is_not_owner() {
-    let aggregation = setup_aggregation();
-    let module_1: ContractAddress = 'module_1'.try_into().unwrap();
-    let module_2: ContractAddress = 'module_2'.try_into().unwrap();
-    aggregation.set_modules(array![module_1, module_2].span());
-    assert(aggregation.get_modules() == array![module_1, module_2].span(), 'set modules failed');
-}
 
 #[test]
 fn test_aggregation_verify() {
-    let aggregation = setup_aggregation();
     let threshold = 2;
 
     // MESSAGEID 
@@ -96,8 +79,10 @@ fn test_aggregation_verify() {
         recipient: VALID_RECIPIENT(),
         body: message_body.clone()
     };
-    let (messageid, messageid_validator_configuration) = setup_messageid_multisig_ism();
     let (_, validators_address, _) = get_message_and_signature();
+    let (messageid, messageid_validator_configuration) = setup_messageid_multisig_ism(
+        validators_address.span()
+    );
     let origin_merkle_tree: u256 = 'origin_merkle_tree_hook'.try_into().unwrap();
     let root: u256 = 'root'.try_into().unwrap();
     let index = 1;
@@ -106,11 +91,12 @@ fn test_aggregation_verify() {
         contract_address: messageid_validator_configuration.contract_address
     };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    messageid_validator_configuration.set_validators(validators_address.span());
     messageid_validator_configuration.set_threshold(5);
     // Noop ism
     let noop_ism = setup_noop_ism();
-
+    let aggregation = setup_aggregation(
+        array![messageid.contract_address.into(), noop_ism.contract_address.into(),].span()
+    );
     let ownable = IOwnableDispatcher { contract_address: aggregation.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     aggregation.set_threshold(threshold);
@@ -119,10 +105,6 @@ fn test_aggregation_verify() {
     concat_metadata.concat(@message_id_metadata);
     // dummy metadata for noop ism
     concat_metadata.concat(@message_id_metadata);
-    aggregation
-        .set_modules(
-            array![messageid.contract_address.into(), noop_ism.contract_address.into(),].span()
-        );
     assert(aggregation.verify(concat_metadata, message), 'Aggregation: verify failed');
 }
 

--- a/contracts/src/tests/isms/test_default_ism.cairo
+++ b/contracts/src/tests/isms/test_default_ism.cairo
@@ -5,8 +5,8 @@ use hyperlane_starknet::interfaces::{
     IMailboxDispatcher, IMailboxDispatcherTrait, IPausableIsmDispatcher, IPausableIsmDispatcherTrait
 };
 use hyperlane_starknet::tests::setup::{
-    setup, setup_trusted_relayer_ism, setup_noop_ism, setup_pausable_ism, mock_setup,
-    DESTINATION_DOMAIN, OWNER, LOCAL_DOMAIN, MAILBOX
+    setup_trusted_relayer_ism, setup_noop_ism, setup_pausable_ism, mock_setup, DESTINATION_DOMAIN,
+    OWNER, LOCAL_DOMAIN, DESTINATION_MAILBOX
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::{start_prank, CheatTarget};
@@ -25,12 +25,12 @@ fn test_verify_noop_ism() {
 #[test]
 fn test_verify_trusted_relayer_ism() {
     let trusted_ism = setup_trusted_relayer_ism();
-    let ownable = IOwnableDispatcher { contract_address: MAILBOX() };
+    let ownable = IOwnableDispatcher { contract_address: DESTINATION_MAILBOX() };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    let mailbox = IMailboxDispatcher { contract_address: MAILBOX() };
+    let mailbox = IMailboxDispatcher { contract_address: DESTINATION_MAILBOX() };
     mailbox.set_default_ism(trusted_ism.contract_address);
     let (mock_recipient, _) = mock_setup(trusted_ism.contract_address);
-    mailbox.set_local_domain(DESTINATION_DOMAIN);
+    // mailbox.set_local_domain(DESTINATION_DOMAIN);
     let array = array![
         0x01020304050607080910111213141516,
         0x01020304050607080910111213141516,

--- a/contracts/src/tests/isms/test_messageid_multisig.cairo
+++ b/contracts/src/tests/isms/test_messageid_multisig.cairo
@@ -12,7 +12,7 @@ use hyperlane_starknet::interfaces::{
     IValidatorConfigurationDispatcherTrait,
 };
 use hyperlane_starknet::tests::setup::{
-    setup, setup_messageid_multisig_ism, OWNER, NEW_OWNER, VALIDATOR_ADDRESS_1, VALIDATOR_ADDRESS_2,
+    setup_messageid_multisig_ism, OWNER, NEW_OWNER, VALIDATOR_ADDRESS_1, VALIDATOR_ADDRESS_2,
     get_message_and_signature, LOCAL_DOMAIN, DESTINATION_DOMAIN, RECIPIENT_ADDRESS,
     build_messageid_metadata, VALID_OWNER, VALID_RECIPIENT
 };
@@ -23,20 +23,21 @@ use snforge_std::{start_prank, CheatTarget};
 
 #[test]
 fn test_set_validators() {
-    let new_validators = array![VALIDATOR_ADDRESS_1(), VALIDATOR_ADDRESS_2()].span();
-    let (_, validators) = setup_messageid_multisig_ism();
+    let new_validators: Array<felt252> = array![
+        VALIDATOR_ADDRESS_1().into(), VALIDATOR_ADDRESS_2().into()
+    ];
+    let (_, validators) = setup_messageid_multisig_ism(new_validators.span());
     let ownable = IOwnableDispatcher { contract_address: validators.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    validators.set_validators(new_validators);
     let validators_span = validators.get_validators();
-    assert(validators_span == new_validators, 'wrong validator address def');
+    assert_eq!(*validators_span.at(0).into(), (*new_validators.at(0)).try_into().unwrap());
+    assert_eq!(*validators_span.at(1).into(), (*new_validators.at(1)).try_into().unwrap());
 }
-
 
 #[test]
 fn test_set_threshold() {
     let new_threshold = 3;
-    let (_, validators) = setup_messageid_multisig_ism();
+    let (_, validators) = setup_messageid_multisig_ism(array!['validator_1'].span());
     let ownable = IOwnableDispatcher { contract_address: validators.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     validators.set_threshold(new_threshold);
@@ -45,31 +46,17 @@ fn test_set_threshold() {
 
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
-fn test_set_validators_fails_if_caller_not_owner() {
-    let new_validators = array![VALIDATOR_ADDRESS_1()].span();
-    let (_, validators) = setup_messageid_multisig_ism();
-    let ownable = IOwnableDispatcher { contract_address: validators.contract_address };
-    start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
-    validators.set_validators(new_validators);
-}
-
-
-#[test]
-#[should_panic(expected: ('Caller is not the owner',))]
+#[should_panic]
 fn test_set_validators_fails_if_null_validator() {
-    let new_validators = array![VALIDATOR_ADDRESS_1(), 0.try_into().unwrap()].span();
-    let (_, validators) = setup_messageid_multisig_ism();
-    let ownable = IOwnableDispatcher { contract_address: validators.contract_address };
-    start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
-    validators.set_validators(new_validators);
+    let new_validators: Span<felt252> = array![VALIDATOR_ADDRESS_1().try_into().unwrap(), 0].span();
+    setup_messageid_multisig_ism(new_validators);
 }
 
 #[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_set_threshold_fails_if_caller_not_owner() {
     let new_threshold = 3;
-    let (_, validators) = setup_messageid_multisig_ism();
+    let (_, validators) = setup_messageid_multisig_ism(array!['validator_1'].span());
     let ownable = IOwnableDispatcher { contract_address: validators.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
     validators.set_threshold(new_threshold);
@@ -108,7 +95,7 @@ fn test_message_id_ism_metadata() {
 
 #[test]
 fn test_message_id_multisig_module_type() {
-    let (messageid, _) = setup_messageid_multisig_ism();
+    let (messageid, _) = setup_messageid_multisig_ism(array!['validator_1'].span());
     assert(
         messageid.module_type() == ModuleType::MESSAGE_ID_MULTISIG(messageid.contract_address),
         'Wrong module type'
@@ -133,8 +120,10 @@ fn test_message_id_multisig_verify_with_4_valid_signatures() {
         recipient: VALID_RECIPIENT(),
         body: message_body.clone()
     };
-    let (messageid, messageid_validator_configuration) = setup_messageid_multisig_ism();
     let (_, validators_address, _) = get_message_and_signature();
+    let (messageid, messageid_validator_configuration) = setup_messageid_multisig_ism(
+        validators_address.span()
+    );
     let origin_merkle_tree: u256 = 'origin_merkle_tree_hook'.try_into().unwrap();
     let root: u256 = 'root'.try_into().unwrap();
     let index = 1;
@@ -143,7 +132,6 @@ fn test_message_id_multisig_verify_with_4_valid_signatures() {
         contract_address: messageid_validator_configuration.contract_address
     };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    messageid_validator_configuration.set_validators(validators_address.span());
     messageid_validator_configuration.set_threshold(4);
     assert(messageid.verify(metadata, message) == true, 'verification failed');
 }
@@ -167,8 +155,10 @@ fn test_message_id_multisig_verify_with_insufficient_valid_signatures() {
         recipient: VALID_RECIPIENT(),
         body: message_body.clone()
     };
-    let (messageid, messageid_validator_config) = setup_messageid_multisig_ism();
     let (_, validators_address, _) = get_message_and_signature();
+    let (messageid, messageid_validator_config) = setup_messageid_multisig_ism(
+        validators_address.span()
+    );
     let origin_merkle_tree: u256 = 'origin_merkle_tree_hook'.try_into().unwrap();
     let root: u256 = 'root'.try_into().unwrap();
     let index = 1;
@@ -177,7 +167,6 @@ fn test_message_id_multisig_verify_with_insufficient_valid_signatures() {
     metadata.update_at(80, 0);
     let ownable = IOwnableDispatcher { contract_address: messageid.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    messageid_validator_config.set_validators(validators_address.span());
     messageid_validator_config.set_threshold(4);
     assert(messageid.verify(metadata, message) == true, 'verification failed');
 }
@@ -201,11 +190,12 @@ fn test_message_id_multisig_verify_with_empty_metadata() {
         recipient: VALID_RECIPIENT(),
         body: message_body.clone()
     };
-    let (messageid, messageid_validator_config) = setup_messageid_multisig_ism();
     let (_, validators_address, _) = get_message_and_signature();
+    let (messageid, messageid_validator_config) = setup_messageid_multisig_ism(
+        validators_address.span()
+    );
     let ownable = IOwnableDispatcher { contract_address: messageid.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    messageid_validator_config.set_validators(validators_address.span());
     messageid_validator_config.set_threshold(4);
     let bytes_metadata = BytesTrait::new_empty();
     assert(messageid.verify(bytes_metadata, message) == true, 'verification failed');

--- a/contracts/src/tests/routing/test_domain_routing_ism.cairo
+++ b/contracts/src/tests/routing/test_domain_routing_ism.cairo
@@ -9,8 +9,7 @@ use hyperlane_starknet::interfaces::{
 };
 use hyperlane_starknet::tests::setup::{
     OWNER, setup_domain_routing_ism, build_messageid_metadata, LOCAL_DOMAIN, DESTINATION_DOMAIN,
-    setup_messageid_multisig_ism, get_message_and_signature, setup_mailbox_client, VALID_OWNER,
-    VALID_RECIPIENT
+    setup_messageid_multisig_ism, get_message_and_signature, VALID_OWNER, VALID_RECIPIENT
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::{start_prank, CheatTarget, stop_prank, ContractClassTrait};
@@ -268,8 +267,10 @@ fn test_verify() {
         recipient: VALID_RECIPIENT(),
         body: message_body.clone()
     };
-    let (messageid, messageid_validator_configuration) = setup_messageid_multisig_ism();
     let (_, validators_address, _) = get_message_and_signature();
+    let (messageid, messageid_validator_configuration) = setup_messageid_multisig_ism(
+        validators_address.span()
+    );
     let origin_merkle_tree: u256 = 'origin_merkle_tree_hook'.try_into().unwrap();
     let root: u256 = 'root'.try_into().unwrap();
     let index = 1;
@@ -280,7 +281,6 @@ fn test_verify() {
         contract_address: messageid_validator_configuration.contract_address
     };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    messageid_validator_configuration.set_validators(validators_address.span());
     messageid_validator_configuration.set_threshold(4);
 
     // ROUTING TESTING

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -323,7 +323,7 @@ pub fn setup_merkle_tree_hook() -> (
     )
 }
 
-pub fn setup_mock_fee_hook() -> IPostDispatchHookDispatcher{
+pub fn setup_mock_fee_hook() -> IPostDispatchHookDispatcher {
     let mock_hook = declare("fee_hook").unwrap();
     let (mock_hook_addr, _) = mock_hook.deploy(@array![]).unwrap();
     IPostDispatchHookDispatcher { contract_address: mock_hook_addr }

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -323,6 +323,12 @@ pub fn setup_merkle_tree_hook() -> (
     )
 }
 
+pub fn setup_mock_fee_hook() -> IPostDispatchHookDispatcher{
+    let mock_hook = declare("fee_hook").unwrap();
+    let (mock_hook_addr, _) = mock_hook.deploy(@array![]).unwrap();
+    IPostDispatchHookDispatcher { contract_address: mock_hook_addr }
+}
+
 pub fn setup_mock_hook() -> IPostDispatchHookDispatcher {
     let mock_hook = declare("hook").unwrap();
     let (mock_hook_addr, _) = mock_hook.deploy(@array![]).unwrap();

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -11,7 +11,8 @@ use hyperlane_starknet::interfaces::{
     IProtocolFeeDispatcherTrait, IMockValidatorAnnounceDispatcher,
     ISpecifiesInterchainSecurityModuleDispatcher, ISpecifiesInterchainSecurityModuleDispatcherTrait,
     IRoutingIsmDispatcher, IRoutingIsmDispatcherTrait, IDomainRoutingIsmDispatcher,
-    IDomainRoutingIsmDispatcherTrait, IPausableIsmDispatcher, IPausableIsmDispatcherTrait
+    IDomainRoutingIsmDispatcherTrait, IPausableIsmDispatcher, IPausableIsmDispatcherTrait,
+    ETH_ADDRESS
 };
 use openzeppelin::account::utils::signature::EthSignature;
 use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
@@ -87,10 +88,22 @@ pub fn MAILBOX() -> ContractAddress {
     'MAILBOX'.try_into().unwrap()
 }
 
+pub fn DESTINATION_MAILBOX() -> ContractAddress {
+    'DESTINATION_MAILBOX'.try_into().unwrap()
+}
+
 pub fn MAILBOX_CLIENT() -> ContractAddress {
     'MAILBOX_CLIENT'.try_into().unwrap()
 }
+pub fn MODULES() -> Span<felt252> {
+    array!['module_1', 'module_2'].span()
+}
 
+pub fn CONTRACT_MODULES() -> Span<ContractAddress> {
+    let module_1 = 'module_1'.try_into().unwrap();
+    let module_2 = 'module_2'.try_into().unwrap();
+    array![module_1, module_2].span()
+}
 pub fn TEST_PROOF() -> Span<u256> {
     array![
         0x09020304050607080910111213141516,
@@ -128,26 +141,51 @@ pub fn TEST_PROOF() -> Span<u256> {
     ]
         .span()
 }
-pub fn setup() -> (
+pub fn setup_mailbox(
+    mailbox_address: ContractAddress,
+    _required_hook: Option<ContractAddress>,
+    _default_mock_hook: Option<ContractAddress>
+) -> (
     IMailboxDispatcher, EventSpy, IPostDispatchHookDispatcher, IInterchainSecurityModuleDispatcher
 ) {
+    let domain = if (mailbox_address == MAILBOX()) {
+        LOCAL_DOMAIN
+    } else {
+        DESTINATION_DOMAIN
+    };
     let mailbox_class = declare("mailbox").unwrap();
-    let mock_hook = setup_mock_hook();
+    let required_hook = match _required_hook {
+        Option::Some(address) => address,
+        Option::None => {
+            let mock_hook_dispatcher = setup_mock_hook();
+            mock_hook_dispatcher.contract_address
+        }
+    };
+    let default_hook = match _default_mock_hook {
+        Option::Some(address) => address,
+        Option::None => { required_hook }
+    };
     let mock_ism = setup_mock_ism();
+    setup_mock_token();
     mailbox_class
         .deploy_at(
             @array![
-                LOCAL_DOMAIN.into(),
+                domain.into(),
                 OWNER().into(),
                 mock_ism.contract_address.into(),
-                mock_hook.contract_address.into(),
-                mock_hook.contract_address.into()
+                default_hook.into(),
+                required_hook.into(),
             ],
-            MAILBOX()
+            mailbox_address
         )
         .unwrap();
-    let mut spy = spy_events(SpyOn::One(MAILBOX()));
-    (IMailboxDispatcher { contract_address: MAILBOX() }, spy, mock_hook, mock_ism)
+    let mut spy = spy_events(SpyOn::One(mailbox_address));
+    (
+        IMailboxDispatcher { contract_address: mailbox_address },
+        spy,
+        IPostDispatchHookDispatcher { contract_address: required_hook },
+        mock_ism
+    )
 }
 
 pub fn mock_setup(
@@ -168,14 +206,14 @@ pub fn setup_mock_ism() -> IInterchainSecurityModuleDispatcher {
     let (mock_ism_addr, _) = mock_ism.deploy(@array![]).unwrap();
     IInterchainSecurityModuleDispatcher { contract_address: mock_ism_addr }
 }
-pub fn setup_messageid_multisig_ism() -> (
-    IInterchainSecurityModuleDispatcher, IValidatorConfigurationDispatcher
-) {
+pub fn setup_messageid_multisig_ism(
+    validators: Span<felt252>
+) -> (IInterchainSecurityModuleDispatcher, IValidatorConfigurationDispatcher) {
     let messageid_multisig_class = declare("messageid_multisig_ism").unwrap();
-
-    let (messageid_multisig_addr, _) = messageid_multisig_class
-        .deploy(@array![OWNER().into()])
-        .unwrap();
+    let mut parameters = Default::default();
+    Serde::serialize(@OWNER(), ref parameters);
+    Serde::serialize(@validators, ref parameters);
+    let (messageid_multisig_addr, _) = messageid_multisig_class.deploy(@parameters).unwrap();
     (
         IInterchainSecurityModuleDispatcher { contract_address: messageid_multisig_addr },
         IValidatorConfigurationDispatcher { contract_address: messageid_multisig_addr }
@@ -183,14 +221,14 @@ pub fn setup_messageid_multisig_ism() -> (
 }
 
 
-pub fn setup_merkleroot_multisig_ism() -> (
-    IInterchainSecurityModuleDispatcher, IValidatorConfigurationDispatcher
-) {
+pub fn setup_merkleroot_multisig_ism(
+    validators: Span<felt252>
+) -> (IInterchainSecurityModuleDispatcher, IValidatorConfigurationDispatcher) {
     let merkleroot_multisig_class = declare("merkleroot_multisig_ism").unwrap();
-
-    let (merkleroot_multisig_addr, _) = merkleroot_multisig_class
-        .deploy(@array![OWNER().into()])
-        .unwrap();
+    let mut parameters = Default::default();
+    Serde::serialize(@OWNER(), ref parameters);
+    Serde::serialize(@validators, ref parameters);
+    let (merkleroot_multisig_addr, _) = merkleroot_multisig_class.deploy(@parameters).unwrap();
     (
         IInterchainSecurityModuleDispatcher { contract_address: merkleroot_multisig_addr },
         IValidatorConfigurationDispatcher { contract_address: merkleroot_multisig_addr }
@@ -199,7 +237,7 @@ pub fn setup_merkleroot_multisig_ism() -> (
 
 
 pub fn setup_mailbox_client() -> IMailboxClientDispatcher {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let mailboxclient_class = declare("mailboxclient").unwrap();
     let res = mailboxclient_class
         .deploy_at(@array![mailbox.contract_address.into(), OWNER().into()], MAILBOX_CLIENT());
@@ -213,7 +251,7 @@ pub fn setup_mailbox_client() -> IMailboxClientDispatcher {
 pub fn setup_default_fallback_routing_ism() -> (
     IInterchainSecurityModuleDispatcher, IRoutingIsmDispatcher, IDomainRoutingIsmDispatcher
 ) {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let default_fallback_routing_ism = declare("default_fallback_routing_ism").unwrap();
     let (default_fallback_routing_ism_addr, _) = default_fallback_routing_ism
         .deploy(@array![OWNER().into(), mailbox.contract_address.into()])
@@ -239,7 +277,7 @@ pub fn setup_domain_routing_ism() -> (
 
 pub fn setup_validator_announce() -> (IValidatorAnnounceDispatcher, EventSpy) {
     let validator_announce_class = declare("validator_announce").unwrap();
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let (validator_announce_addr, _) = validator_announce_class
         .deploy(@array![mailbox.contract_address.into()])
         .unwrap();
@@ -257,19 +295,21 @@ pub fn setup_mock_validator_announce(
     IMockValidatorAnnounceDispatcher { contract_address: validator_announce_addr }
 }
 
-pub fn setup_aggregation() -> IAggregationDispatcher {
+pub fn setup_aggregation(modules: Span<felt252>) -> IAggregationDispatcher {
     let aggregation_class = declare("aggregation").unwrap();
-    let (aggregation_addr, _) = aggregation_class.deploy(@array![OWNER().into()]).unwrap();
+    let mut parameters = Default::default();
+    Serde::serialize(@OWNER(), ref parameters);
+    Serde::serialize(@modules, ref parameters);
+    let (aggregation_addr, _) = aggregation_class.deploy(@parameters).unwrap();
     IAggregationDispatcher { contract_address: aggregation_addr }
 }
 
 pub fn setup_merkle_tree_hook() -> (
     IMerkleTreeHookDispatcher, IPostDispatchHookDispatcher, EventSpy
 ) {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let merkle_tree_hook_class = declare("merkle_tree_hook").unwrap();
-    let res = merkle_tree_hook_class
-        .deploy(@array![mailbox.contract_address.into(), OWNER().into()]);
+    let res = merkle_tree_hook_class.deploy(@array![mailbox.contract_address.into()]);
     if (res.is_err()) {
         panic(res.unwrap_err());
     }
@@ -306,7 +346,7 @@ pub fn setup_pausable_ism() -> (IInterchainSecurityModuleDispatcher, IPausableIs
 }
 
 pub fn setup_trusted_relayer_ism() -> IInterchainSecurityModuleDispatcher {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(DESTINATION_MAILBOX(), Option::None, Option::None);
     let trusted_relayer_ism = declare("trusted_relayer_ism").unwrap();
     let (trusted_relayer_ism_addr, _) = trusted_relayer_ism
         .deploy(@array![mailbox.contract_address.into(), OWNER().into()])
@@ -335,9 +375,9 @@ pub fn build_messageid_metadata(origin_merkle_tree_hook: u256, root: u256, index
 }
 
 // Configuration from the main cairo repo: https://github.com/starkware-libs/cairo/blob/main/corelib/src/test/secp256k1_test.cairo
-pub fn get_message_and_signature() -> (u256, Array<EthAddress>, Array<EthSignature>) {
+pub fn get_message_and_signature() -> (u256, Array<felt252>, Array<EthSignature>) {
     let msg_hash = 0xEBC2F3E10A13E54662AB9B1ABB83E954EA31E5622AF8239EB97D22CC351324D2;
-    let validators_array: Array<EthAddress> = array![
+    let validators_array: Array<felt252> = array![
         0x8a719a6529c8fdef4df79079f47ae74fd4037b08.try_into().unwrap(),
         0xb93289817c013182bf7f7d1e2e4577a77d4be7d7.try_into().unwrap(),
         0x92316e3bacc840258925ba3eba801aaae5347a09.try_into().unwrap(),
@@ -405,9 +445,9 @@ pub fn build_merkle_metadata(
 
 
 // Configuration from the main cairo repo: https://github.com/starkware-libs/cairo/blob/main/corelib/src/test/secp256k1_test.cairo
-pub fn get_merkle_message_and_signature() -> (u256, Array<EthAddress>, Array<EthSignature>) {
+pub fn get_merkle_message_and_signature() -> (u256, Array<felt252>, Array<EthSignature>) {
     let msg_hash = 0x4B73BFF28F5521D6F2F38F344427CCF23DCE6BA26F96C4EB14C1656348F4D153;
-    let validators_array: Array<EthAddress> = array![
+    let validators_array: Array<felt252> = array![
         0xbce3b51b0d6ff506e23ddfd6789ac5a60a1103a4.try_into().unwrap(),
         0xe0c60d0f83f70f5eb497bfc7a2315cb5ca88f801.try_into().unwrap(),
         0x0dc578af77510a16da2a3557e822085a95df6962.try_into().unwrap(),
@@ -440,14 +480,18 @@ pub fn get_merkle_message_and_signature() -> (u256, Array<EthAddress>, Array<Eth
     (msg_hash, validators_array, signatures)
 }
 
-
-pub fn setup_protocol_fee() -> (
-    IERC20Dispatcher, IProtocolFeeDispatcher, IPostDispatchHookDispatcher
-) {
+pub fn setup_mock_token() -> IERC20Dispatcher {
     let fee_token_class = declare("mock_fee_token").unwrap();
     let (fee_token_addr, _) = fee_token_class
-        .deploy(@array![INITIAL_SUPPLY.low.into(), INITIAL_SUPPLY.high.into(), OWNER().into()])
+        .deploy_at(
+            @array![INITIAL_SUPPLY.low.into(), INITIAL_SUPPLY.high.into(), OWNER().into()],
+            ETH_ADDRESS()
+        )
         .unwrap();
+    IERC20Dispatcher { contract_address: fee_token_addr }
+}
+
+pub fn setup_protocol_fee() -> (IProtocolFeeDispatcher, IPostDispatchHookDispatcher) {
     let protocol_fee_class = declare("protocol_fee").unwrap();
     let (protocol_fee_addr, _) = protocol_fee_class
         .deploy(
@@ -458,12 +502,11 @@ pub fn setup_protocol_fee() -> (
                 PROTOCOL_FEE.high.into(),
                 BENEFICIARY().into(),
                 OWNER().into(),
-                fee_token_addr.into()
+                ETH_ADDRESS().into()
             ]
         )
         .unwrap();
     (
-        IERC20Dispatcher { contract_address: fee_token_addr },
         IProtocolFeeDispatcher { contract_address: protocol_fee_addr },
         IPostDispatchHookDispatcher { contract_address: protocol_fee_addr }
     )

--- a/contracts/src/tests/test_mailbox.cairo
+++ b/contracts/src/tests/test_mailbox.cairo
@@ -1,32 +1,36 @@
 use alexandria_bytes::{Bytes, BytesTrait};
 use hyperlane_starknet::contracts::libs::message::{Message, MessageTrait, HYPERLANE_VERSION};
 use hyperlane_starknet::contracts::mailbox::mailbox;
-use hyperlane_starknet::interfaces::IMessageRecipientDispatcherTrait;
-use hyperlane_starknet::interfaces::{IMailbox, IMailboxDispatcher, IMailboxDispatcherTrait};
+use hyperlane_starknet::interfaces::{
+    IMailbox, IMailboxDispatcher, IMailboxDispatcherTrait, IMessageRecipientDispatcherTrait,
+    ETH_ADDRESS
+};
 use hyperlane_starknet::tests::setup::{
-    setup, mock_setup, OWNER, LOCAL_DOMAIN, NEW_OWNER, DEFAULT_ISM, NEW_DEFAULT_ISM,
-    NEW_DEFAULT_HOOK, NEW_REQUIRED_HOOK, DESTINATION_DOMAIN, RECIPIENT_ADDRESS,
+    setup_mailbox, mock_setup, OWNER, LOCAL_DOMAIN, NEW_OWNER, DEFAULT_ISM, NEW_DEFAULT_ISM,
+    NEW_DEFAULT_HOOK, NEW_REQUIRED_HOOK, DESTINATION_DOMAIN, RECIPIENT_ADDRESS, MAILBOX,
+    DESTINATION_MAILBOX, setup_protocol_fee, setup_mock_hook, PROTOCOL_FEE, INITIAL_SUPPLY
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
+use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
 use snforge_std::cheatcodes::events::EventAssertions;
 use snforge_std::{start_prank, CheatTarget, stop_prank};
 
 #[test]
 fn test_local_domain() {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     assert(mailbox.get_local_domain() == LOCAL_DOMAIN, 'Wrong local domain');
 }
 #[test]
 fn test_owner() {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     assert(ownable.owner() == OWNER(), 'Wrong contract owner');
 }
 
 #[test]
 fn test_transfer_ownership() {
-    let (mailbox, mut spy, _, _) = setup();
+    let (mailbox, mut spy, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     ownable.transfer_ownership(NEW_OWNER());
@@ -49,7 +53,7 @@ fn test_transfer_ownership() {
 
 #[test]
 fn test_set_default_hook() {
-    let (mailbox, mut spy, mock_hook, _) = setup();
+    let (mailbox, mut spy, mock_hook, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     mailbox.set_default_hook(mock_hook.contract_address);
@@ -62,7 +66,7 @@ fn test_set_default_hook() {
 
 #[test]
 fn test_set_required_hook() {
-    let (mailbox, mut spy, mock_hook, _) = setup();
+    let (mailbox, mut spy, mock_hook, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     mailbox.set_required_hook(mock_hook.contract_address);
@@ -77,7 +81,7 @@ fn test_set_required_hook() {
 
 #[test]
 fn test_set_default_ism() {
-    let (mailbox, mut spy, _, mock_ism) = setup();
+    let (mailbox, mut spy, _, mock_ism) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     mailbox.set_default_ism(mock_ism.contract_address);
@@ -90,7 +94,7 @@ fn test_set_default_ism() {
 #[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_set_default_hook_fails_if_not_owner() {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
     mailbox.set_default_hook(NEW_DEFAULT_HOOK());
@@ -99,7 +103,7 @@ fn test_set_default_hook_fails_if_not_owner() {
 #[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_set_required_hook_fails_if_not_owner() {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
     mailbox.set_required_hook(NEW_REQUIRED_HOOK());
@@ -108,7 +112,7 @@ fn test_set_required_hook_fails_if_not_owner() {
 #[test]
 #[should_panic(expected: ('Caller is not the owner',))]
 fn test_set_default_ism_fails_if_not_owner() {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
     mailbox.set_default_ism(NEW_DEFAULT_ISM());
@@ -116,7 +120,7 @@ fn test_set_default_ism_fails_if_not_owner() {
 
 #[test]
 fn test_dispatch() {
-    let (mailbox, mut spy, _, _) = setup();
+    let (mailbox, mut spy, _, _) = setup_mailbox(MAILBOX(), Option::None, Option::None);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     let array = array![
@@ -138,7 +142,7 @@ fn test_dispatch() {
     let (message_id, _) = MessageTrait::format_message(message.clone());
     mailbox
         .dispatch(
-            DESTINATION_DOMAIN, RECIPIENT_ADDRESS(), message_body, Option::None, Option::None
+            DESTINATION_DOMAIN, RECIPIENT_ADDRESS(), message_body, 0, Option::None, Option::None
         );
     let expected_event = mailbox::Event::Dispatch(
         mailbox::Dispatch {
@@ -161,14 +165,206 @@ fn test_dispatch() {
     assert(mailbox.get_latest_dispatched_id() == message_id, 'Failed to fetch latest id');
 }
 
+
+#[test]
+fn test_dispatch_with_protocol_fee_hook() {
+    let (_, protocol_fee_hook) = setup_protocol_fee();
+    let mock_hook = setup_mock_hook();
+    let (mailbox, mut spy, _, _) = setup_mailbox(
+        MAILBOX(),
+        Option::Some(protocol_fee_hook.contract_address),
+        Option::Some(mock_hook.contract_address)
+    );
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    erc20_dispatcher.approve(MAILBOX(), 2 * PROTOCOL_FEE);
+    stop_prank(CheatTarget::One(ownable.contract_address));
+    // The owner has the initial fee token supply
+    let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    let array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
+
+    let message_body = BytesTrait::new(42, array);
+    let message = Message {
+        version: HYPERLANE_VERSION,
+        nonce: 0,
+        origin: LOCAL_DOMAIN,
+        sender: OWNER(),
+        destination: DESTINATION_DOMAIN,
+        recipient: RECIPIENT_ADDRESS(),
+        body: message_body.clone()
+    };
+    let (message_id, _) = MessageTrait::format_message(message.clone());
+    mailbox
+        .dispatch(
+            DESTINATION_DOMAIN,
+            RECIPIENT_ADDRESS(),
+            message_body,
+            PROTOCOL_FEE,
+            Option::None,
+            Option::None
+        );
+    let expected_event = mailbox::Event::Dispatch(
+        mailbox::Dispatch {
+            sender: OWNER(),
+            destination_domain: DESTINATION_DOMAIN,
+            recipient_address: RECIPIENT_ADDRESS(),
+            message: message
+        }
+    );
+    let expected_event_id = mailbox::Event::DispatchId(mailbox::DispatchId { id: message_id });
+
+    spy
+        .assert_emitted(
+            @array![
+                (mailbox.contract_address, expected_event),
+                (mailbox.contract_address, expected_event_id)
+            ]
+        );
+
+    // balance check 
+    assert_eq!(erc20_dispatcher.balance_of(OWNER()), INITIAL_SUPPLY - PROTOCOL_FEE);
+    assert(mailbox.get_latest_dispatched_id() == message_id, 'Failed to fetch latest id');
+}
+
+
+#[test]
+#[should_panic(expected: ('Provided fee < required fee',))]
+fn test_dispatch_with_protocol_fee_hook_fails_if_provided_fee_lower_than_required_fee() {
+    let (_, protocol_fee_hook) = setup_protocol_fee();
+    let mock_hook = setup_mock_hook();
+
+    let (mailbox, _, _, _) = setup_mailbox(
+        MAILBOX(),
+        Option::Some(protocol_fee_hook.contract_address),
+        Option::Some(mock_hook.contract_address)
+    );
+    let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    // We transfer some token to the new owner
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    erc20_dispatcher.transfer(NEW_OWNER(), PROTOCOL_FEE - 10);
+
+    // The new owner has has PROTOCOL_FEE -10 tokens so the required hook post dispatch fails
+    let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
+    start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
+    erc20_dispatcher.approve(MAILBOX(), PROTOCOL_FEE - 10);
+    let array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
+
+    let message_body = BytesTrait::new(42, array);
+    mailbox
+        .dispatch(
+            DESTINATION_DOMAIN,
+            RECIPIENT_ADDRESS(),
+            message_body,
+            PROTOCOL_FEE - 10,
+            Option::None,
+            Option::None
+        );
+}
+
+
+#[test]
+#[should_panic(expected: ('Insufficient balance',))]
+fn test_dispatch_with_protocol_fee_hook_fails_if_user_balance_lower_than_fee_amount() {
+    let (_, protocol_fee_hook) = setup_protocol_fee();
+    let mock_hook = setup_mock_hook();
+
+    let (mailbox, _, _, _) = setup_mailbox(
+        MAILBOX(),
+        Option::Some(protocol_fee_hook.contract_address),
+        Option::Some(mock_hook.contract_address)
+    );
+    let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    // We transfer some token to the new owner
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    erc20_dispatcher.transfer(NEW_OWNER(), PROTOCOL_FEE - 10);
+
+    // The new owner has has PROTOCOL_FEE -10 tokens so the required hook post dispatch fails
+    let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
+    start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
+    let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
+    erc20_dispatcher.approve(MAILBOX(), PROTOCOL_FEE - 10);
+    let array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
+
+    let message_body = BytesTrait::new(42, array);
+    mailbox
+        .dispatch(
+            DESTINATION_DOMAIN,
+            RECIPIENT_ADDRESS(),
+            message_body,
+            PROTOCOL_FEE,
+            Option::None,
+            Option::None
+        );
+}
+
+
+#[test]
+#[should_panic(expected: ('Insufficient allowance',))]
+fn test_dispatch_with_protocol_fee_hook_fails_if_insufficient_allowance() {
+    let (_, protocol_fee_hook) = setup_protocol_fee();
+    let mock_hook = setup_mock_hook();
+
+    let (mailbox, _, _, _) = setup_mailbox(
+        MAILBOX(),
+        Option::Some(protocol_fee_hook.contract_address),
+        Option::Some(mock_hook.contract_address)
+    );
+    let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
+    start_prank(CheatTarget::One(ownable.contract_address), OWNER());
+    // We transfer some token to the new owner
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    erc20_dispatcher.transfer(NEW_OWNER(), PROTOCOL_FEE);
+
+    // The new owner has has PROTOCOL_FEE -10 tokens so the required hook post dispatch fails
+    let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
+    start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
+    erc20_dispatcher.approve(MAILBOX(), PROTOCOL_FEE - 10);
+
+    let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
+    start_prank(CheatTarget::One(ownable.contract_address), NEW_OWNER());
+    let array = array![
+        0x01020304050607080910111213141516,
+        0x01020304050607080910111213141516,
+        0x01020304050607080910000000000000
+    ];
+
+    let message_body = BytesTrait::new(42, array);
+    mailbox
+        .dispatch(
+            DESTINATION_DOMAIN,
+            RECIPIENT_ADDRESS(),
+            message_body,
+            PROTOCOL_FEE,
+            Option::None,
+            Option::None
+        );
+}
+
+
 #[test]
 fn test_process() {
-    let (mailbox, mut spy, _, _) = setup();
+    let (mailbox, mut spy, _, _) = setup_mailbox(DESTINATION_MAILBOX(), Option::None, Option::None);
     let mock_ism_address = mailbox.get_default_ism();
     let (mock_recipient, _) = mock_setup(mock_ism_address);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    mailbox.set_local_domain(DESTINATION_DOMAIN);
     let array = array![
         0x01020304050607080910111213141516,
         0x01020304050607080910111213141516,
@@ -214,12 +410,11 @@ fn test_process() {
 #[test]
 #[should_panic(expected: ('Wrong hyperlane version',))]
 fn test_process_fails_if_version_mismatch() {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(DESTINATION_MAILBOX(), Option::None, Option::None);
     let mock_ism_address = mailbox.get_default_ism();
     let (mock_recipient, _) = mock_setup(mock_ism_address);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    mailbox.set_local_domain(DESTINATION_DOMAIN);
     let array = array![
         0x01020304050607080910111213141516,
         0x01020304050607080910111213141516,
@@ -243,12 +438,11 @@ fn test_process_fails_if_version_mismatch() {
 #[test]
 #[should_panic(expected: ('Unexpected destination',))]
 fn test_process_fails_if_destination_domain_does_not_match_local_domain() {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(DESTINATION_MAILBOX(), Option::None, Option::None);
     let mock_ism_address = mailbox.get_default_ism();
     let (mock_recipient, _) = mock_setup(mock_ism_address);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    mailbox.set_local_domain(DESTINATION_DOMAIN);
     let array = array![
         0x01020304050607080910111213141516,
         0x01020304050607080910111213141516,
@@ -272,12 +466,12 @@ fn test_process_fails_if_destination_domain_does_not_match_local_domain() {
 #[test]
 #[should_panic(expected: ('Mailbox: already delivered',))]
 fn test_process_fails_if_already_delivered() {
-    let (mailbox, _, _, _) = setup();
+    let (mailbox, _, _, _) = setup_mailbox(DESTINATION_MAILBOX(), Option::None, Option::None);
     let mock_ism_address = mailbox.get_default_ism();
     let (mock_recipient, _) = mock_setup(mock_ism_address);
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
-    mailbox.set_local_domain(DESTINATION_DOMAIN);
+    // mailbox.set_local_domain(DESTINATION_DOMAIN);
     let array = array![
         0x01020304050607080910111213141516,
         0x01020304050607080910111213141516,

--- a/contracts/src/tests/test_mailbox.cairo
+++ b/contracts/src/tests/test_mailbox.cairo
@@ -8,7 +8,8 @@ use hyperlane_starknet::interfaces::{
 use hyperlane_starknet::tests::setup::{
     setup_mailbox, mock_setup, OWNER, LOCAL_DOMAIN, NEW_OWNER, DEFAULT_ISM, NEW_DEFAULT_ISM,
     NEW_DEFAULT_HOOK, NEW_REQUIRED_HOOK, DESTINATION_DOMAIN, RECIPIENT_ADDRESS, MAILBOX,
-    DESTINATION_MAILBOX, setup_protocol_fee, setup_mock_hook, PROTOCOL_FEE, INITIAL_SUPPLY, setup_mock_fee_hook
+    DESTINATION_MAILBOX, setup_protocol_fee, setup_mock_hook, PROTOCOL_FEE, INITIAL_SUPPLY,
+    setup_mock_fee_hook
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
@@ -233,7 +234,6 @@ fn test_dispatch_with_protocol_fee_hook() {
 }
 
 
-
 #[test]
 fn test_dispatch_with_two_fee_hook() {
     let (_, protocol_fee_hook) = setup_protocol_fee();
@@ -247,7 +247,7 @@ fn test_dispatch_with_two_fee_hook() {
     let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     // (mock_fee_hook consummes 3 * PROTOCOL_FEE)
-    erc20_dispatcher.approve(MAILBOX(),  5* PROTOCOL_FEE);
+    erc20_dispatcher.approve(MAILBOX(), 5 * PROTOCOL_FEE);
     stop_prank(CheatTarget::One(ownable.contract_address));
     // The owner has the initial fee token supply
     let ownable = IOwnableDispatcher { contract_address: mailbox.contract_address };
@@ -297,7 +297,7 @@ fn test_dispatch_with_two_fee_hook() {
         );
 
     // balance check
-    assert_eq!(erc20_dispatcher.balance_of(OWNER()), INITIAL_SUPPLY - 4 *PROTOCOL_FEE);
+    assert_eq!(erc20_dispatcher.balance_of(OWNER()), INITIAL_SUPPLY - 4 * PROTOCOL_FEE);
     assert(mailbox.get_latest_dispatched_id() == message_id, 'Failed to fetch latest id');
 }
 #[test]


### PR DESCRIPTION
Resolves #45 

## Changes

Following Hyperlane team recommendations, we removed the possibility to modify the `local_domain` associated to the mailbox. 
Removed upgradeability for the Merkle Tree Hook contract
Refactor `mailboxClientProxy`
Modules and Validators are now set as constructor parameters, and cannot be changed afterwards

## Additions

We detailed the fee process in the dispatch function. In order to do so, we needed to add a `_fee_amount` parameter for the required functions. The process is that the dispatch function calls and send the `required_fee` to the hook contract (fetched thanks to the `quote_dispatch` function available for hooks). If the fee amount provided is enough to cover the `default_fee`, the mailbox send the default fee to the default hook.