### PR TITLE
Feat: Validator Announce storage location as array

### DIFF
--- a/contracts/src/contracts/isms/multisig/validator_announce.cairo
+++ b/contracts/src/contracts/isms/multisig/validator_announce.cairo
@@ -39,7 +39,7 @@ pub mod validator_announce {
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]
         upgradeable: UpgradeableComponent::Storage,
-        storage_location_len : LegacyMap::<EthAddress, u256>,
+        storage_location_len: LegacyMap::<EthAddress, u256>,
         storage_locations: LegacyMap::<(EthAddress, u256), Array<felt252>>,
         replay_protection: LegacyMap::<felt252, bool>,
         validators: LegacyMap::<EthAddress, EthAddress>,
@@ -140,7 +140,7 @@ pub mod validator_announce {
             };
             let mut validator_len = self.storage_location_len.read(_validator);
             self.storage_locations.write((_validator, validator_len), _storage_location);
-            self.storage_location_len.write(_validator, validator_len +1);
+            self.storage_location_len.write(_validator, validator_len + 1);
             self.replay_protection.write(replay_id, true);
             self
                 .emit(
@@ -171,12 +171,13 @@ pub mod validator_announce {
                         let mut cur_idx = 0;
                         let validator_len = self.storage_location_len.read(*validator);
                         let mut validator_metadata = array![];
-                        loop{
-                            if (cur_idx == validator_len){
-                                break();
+                        loop {
+                            if (cur_idx == validator_len) {
+                                break ();
                             }
-                            validator_metadata.append(self.storage_locations.read((*validator,cur_idx)));
-                            cur_idx +=1;
+                            validator_metadata
+                                .append(self.storage_locations.read((*validator, cur_idx)));
+                            cur_idx += 1;
                         };
                         metadata.append(validator_metadata.span())
                     },

--- a/contracts/src/contracts/isms/multisig/validator_announce.cairo
+++ b/contracts/src/contracts/isms/multisig/validator_announce.cairo
@@ -137,8 +137,13 @@ pub mod validator_announce {
                     self.validators.write(last_validator, _validator);
                 }
             };
-
-            self.storage_location.write(_validator, _storage_location);
+            let mut storage_location = self.storage_location.read(_validator);
+            let concat_storage_location = if (storage_location.len() ==0){
+                _storage_location
+            } else {
+                storage_location.concat(@_storage_location)
+            };
+            self.storage_location.write(_validator, concat_storage_location);
             self.replay_protection.write(replay_id, true);
             self
                 .emit(

--- a/contracts/src/contracts/isms/multisig/validator_announce.cairo
+++ b/contracts/src/contracts/isms/multisig/validator_announce.cairo
@@ -138,7 +138,7 @@ pub mod validator_announce {
                 }
             };
             let mut storage_location = self.storage_location.read(_validator);
-            let concat_storage_location = if (storage_location.len() ==0){
+            let concat_storage_location = if (storage_location.len() == 0) {
                 _storage_location
             } else {
                 storage_location.concat(@_storage_location)

--- a/contracts/src/contracts/isms/multisig/validator_announce.cairo
+++ b/contracts/src/contracts/isms/multisig/validator_announce.cairo
@@ -39,7 +39,8 @@ pub mod validator_announce {
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]
         upgradeable: UpgradeableComponent::Storage,
-        storage_location: LegacyMap::<EthAddress, Array<felt252>>,
+        storage_location_len : LegacyMap::<EthAddress, u256>,
+        storage_locations: LegacyMap::<(EthAddress, u256), Array<felt252>>,
         replay_protection: LegacyMap::<felt252, bool>,
         validators: LegacyMap::<EthAddress, EthAddress>,
     }
@@ -137,13 +138,9 @@ pub mod validator_announce {
                     self.validators.write(last_validator, _validator);
                 }
             };
-            let mut storage_location = self.storage_location.read(_validator);
-            let concat_storage_location = if (storage_location.len() == 0) {
-                _storage_location
-            } else {
-                storage_location.concat(@_storage_location)
-            };
-            self.storage_location.write(_validator, concat_storage_location);
+            let mut validator_len = self.storage_location_len.read(_validator);
+            self.storage_locations.write((_validator, validator_len), _storage_location);
+            self.storage_location_len.write(_validator, validator_len +1);
             self.replay_protection.write(replay_id, true);
             self
                 .emit(
@@ -166,12 +163,21 @@ pub mod validator_announce {
         /// Span<Span<felt252>> -  A list of registered storage metadata
         fn get_announced_storage_locations(
             self: @ContractState, mut _validators: Span<EthAddress>
-        ) -> Span<Span<felt252>> {
+        ) -> Span<Span<Array<felt252>>> {
             let mut metadata = array![];
             loop {
                 match _validators.pop_front() {
                     Option::Some(validator) => {
-                        let validator_metadata = self.storage_location.read(*validator);
+                        let mut cur_idx = 0;
+                        let validator_len = self.storage_location_len.read(*validator);
+                        let mut validator_metadata = array![];
+                        loop{
+                            if (cur_idx == validator_len){
+                                break();
+                            }
+                            validator_metadata.append(self.storage_locations.read((*validator,cur_idx)));
+                            cur_idx +=1;
+                        };
                         metadata.append(validator_metadata.span())
                     },
                     Option::None => { break (); }

--- a/contracts/src/contracts/mocks/mock_validator_announce.cairo
+++ b/contracts/src/contracts/mocks/mock_validator_announce.cairo
@@ -3,26 +3,39 @@ pub mod mock_validator_announce {
     use alexandria_bytes::{Bytes, BytesTrait};
     use alexandria_data_structures::array_ext::ArrayTraitExt;
     use core::poseidon::poseidon_hash_span;
-    use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::{
-        HYPERLANE_ANNOUNCEMENT
+    use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::HYPERLANE_ANNOUNCEMENT;
+    use hyperlane_starknet::interfaces::{
+        IMailboxClientDispatcher, IMailboxClientDispatcherTrait, IValidatorAnnounce
     };
-    use hyperlane_starknet::interfaces::IMockValidatorAnnounce;
-    use hyperlane_starknet::interfaces::{IMailboxClientDispatcher, IMailboxClientDispatcherTrait};
     use hyperlane_starknet::utils::keccak256::{
-        reverse_endianness, to_eth_signature, compute_keccak, ByteData, u64_word_size,
-        u256_word_size, HASH_SIZE, bool_is_eth_signature_valid
+        reverse_endianness, to_eth_signature, compute_keccak, ByteData, u256_word_size,
+        u64_word_size, HASH_SIZE, bool_is_eth_signature_valid
     };
     use hyperlane_starknet::utils::store_arrays::StoreFelt252Array;
+    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
+    use starknet::{
+        ContractAddress, ClassHash, EthAddress, secp256_trait::{Signature, signature_from_vrs}
+    };
 
-    use starknet::ContractAddress;
-    use starknet::EthAddress;
-    use starknet::secp256_trait::{Signature, signature_from_vrs};
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+
+    #[abi(embed_v0)]
+    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
     struct Storage {
-        mailboxclient: ContractAddress,
+        mailbox: ContractAddress,  // for testing purpose, we set directly the mailbox address here
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        upgradeable: UpgradeableComponent::Storage,
         domain: u32,
-        storage_location: LegacyMap::<EthAddress, Array<felt252>>,
+        storage_location_len : LegacyMap::<EthAddress, u256>,
+        storage_locations: LegacyMap::<(EthAddress, u256), Array<felt252>>,
         replay_protection: LegacyMap::<felt252, bool>,
         validators: LegacyMap::<EthAddress, EthAddress>,
     }
@@ -31,96 +44,163 @@ pub mod mock_validator_announce {
     #[event]
     #[derive(Drop, starknet::Event)]
     pub enum Event {
-        ValidatorAnnouncement: ValidatorAnnouncement
+        ValidatorAnnouncement: ValidatorAnnouncement,
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        UpgradeableEvent: UpgradeableComponent::Event,
     }
 
     #[derive(starknet::Event, Drop)]
     pub struct ValidatorAnnouncement {
         pub validator: EthAddress,
-        pub storage_location: Array<felt252>
+        pub storage_location: Span<felt252>
     }
 
     pub mod Errors {
         pub const REPLAY_PROTECTION_ERROR: felt252 = 'Announce already occured';
         pub const WRONG_SIGNER: felt252 = 'Wrong signer';
     }
-
     #[constructor]
-    fn constructor(ref self: ContractState, _mailbox_client: ContractAddress, _domain: u32) {
-        self.mailboxclient.write(_mailbox_client);
+    fn constructor(ref self: ContractState, _mailbox: ContractAddress, _domain: u32) {
+        self.mailbox.write(_mailbox);
         self.domain.write(_domain);
     }
 
+
     #[abi(embed_v0)]
-    impl IValidatorAnnonceImpl of IMockValidatorAnnounce<ContractState> {
+    impl Upgradeable of IUpgradeable<ContractState> {
+        /// Upgrades the contract to a new implementation.
+        /// Callable only by the owner
+        /// 
+        /// # Arguments
+        ///
+        /// * `new_class_hash` - The class hash of the new implementation.
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            self.ownable.assert_only_owner();
+            self.upgradeable._upgrade(new_class_hash);
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl IValidatorAnnonceImpl of IValidatorAnnounce<ContractState> {
+        /// Announces a validator signature storage location
+        /// Dev: reverts if announce already occured or if wrong signer
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_validator` - The validator to consider
+        /// * - `_storage_location` - Information encoding the location of signed
+        /// * - `_signature` -The signed validator announcement
+        /// 
+        /// # Returns 
+        /// 
+        /// boolean -  True upon success
         fn announce(
             ref self: ContractState,
             _validator: EthAddress,
-            mut _storage_location: Array<felt252>,
+            _storage_location: Array<felt252>,
             _signature: Bytes
         ) -> bool {
             let felt252_validator: felt252 = _validator.into();
             let mut _input: Array<u256> = array![felt252_validator.into()];
             let mut u256_storage_location: Array<u256> = array![];
+            let mut cur_idx = 0;
+            let span_storage_location = _storage_location.span();
             loop {
-                match _storage_location.pop_front() {
-                    Option::Some(storage) => u256_storage_location.append(storage.into()),
-                    Option::None(()) => { break (); },
+                if (cur_idx == span_storage_location.len()) {
+                    break ();
                 }
+                u256_storage_location.append((*span_storage_location.at(cur_idx)).into());
+                cur_idx += 1;
             };
             let replay_id = poseidon_hash_span(
                 array![felt252_validator].concat(@_storage_location).span()
             );
             assert(!self.replay_protection.read(replay_id), Errors::REPLAY_PROTECTION_ERROR);
             let announcement_digest = self.get_announcement_digest(u256_storage_location);
-            let signature: Signature = convert_to_signature(_signature);
-            assert(
-                bool_is_eth_signature_valid(announcement_digest, signature, _validator),
-                Errors::WRONG_SIGNER
-            );
-            match find_validators_index(@self, _validator) {
-                Option::Some(_) => {},
-                Option::None(()) => {
-                    let last_validator = find_last_validator(@self);
+            let signature: Signature = self.convert_to_signature(_signature);
+            // Remove the signature verification ONLY for testing double announcement (assuming validator signature is correct in both cases)
+            // assert(
+            //     bool_is_eth_signature_valid(announcement_digest, signature, _validator),
+            //     Errors::WRONG_SIGNER
+            // );
+            match self.find_validators_index(_validator) {
+                Option::Some => {},
+                Option::None => {
+                    let last_validator = self.find_last_validator();
                     self.validators.write(last_validator, _validator);
                 }
             };
-            self.storage_location.write(_validator, _storage_location.clone());
+            let mut validator_len = self.storage_location_len.read(_validator);
+            self.storage_locations.write((_validator, validator_len), _storage_location);
+            self.storage_location_len.write(_validator, validator_len +1);
+            self.replay_protection.write(replay_id, true);
             self
                 .emit(
                     ValidatorAnnouncement {
-                        validator: _validator, storage_location: _storage_location
+                        validator: _validator, storage_location: span_storage_location
                     }
                 );
             true
         }
 
+
+        /// Returns a list of all announced storage locations
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_validators` - The span of validators to get registrations for
+        /// 
+        /// # Returns 
+        /// 
+        /// Span<Span<felt252>> -  A list of registered storage metadata
         fn get_announced_storage_locations(
             self: @ContractState, mut _validators: Span<EthAddress>
-        ) -> Span<Span<felt252>> {
+        ) -> Span<Span<Array<felt252>>> {
             let mut metadata = array![];
             loop {
                 match _validators.pop_front() {
                     Option::Some(validator) => {
-                        let validator_metadata = self.storage_location.read(*validator);
+                        let mut cur_idx = 0;
+                        let validator_len = self.storage_location_len.read(*validator);
+                        let mut validator_metadata = array![];
+                        loop{
+                            if (cur_idx == validator_len){
+                                break();
+                            }
+                            validator_metadata.append(self.storage_locations.read((*validator,cur_idx)));
+                            cur_idx +=1;
+                        };
                         metadata.append(validator_metadata.span())
                     },
-                    Option::None(()) => { break (); }
+                    Option::None => { break (); }
                 }
             };
             metadata.span()
         }
 
+        /// Returns a list of validators that have made announcements
         fn get_announced_validators(self: @ContractState) -> Span<EthAddress> {
-            build_validators_array(self)
+            self.build_validators_array()
         }
 
+
+        /// Returns the digest validators are expected to sign when signing announcements.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_storage_location` - Storage location as array of u256
+        /// 
+        /// # Returns 
+        /// 
+        /// u256 -  The digest of the announcement.
         fn get_announcement_digest(
             self: @ContractState, mut _storage_location: Array<u256>
         ) -> u256 {
-            let mailboxclient_address = self.mailboxclient.read();
+            let mailboxclient_address = self.mailbox.read();
             let domain = self.domain.read();
-            let domain_hash = domain_hash(self, mailboxclient_address, domain);
+            let domain_hash = self.domain_hash(mailboxclient_address, domain);
             let mut byte_data_storage_location = array![];
             loop {
                 match _storage_location.pop_front() {
@@ -144,64 +224,409 @@ pub mod mock_validator_announce {
         }
     }
 
+    #[generate_trait]
+    pub impl ValidatorAnnounceInternalImpl of InternalTrait {
+        /// Converts a byte signature into a standard singature format (see Signature structure)
+        /// 
+        /// # Arguments
+        /// 
+        /// * - ` _signature` - The byte encoded Signature
+        /// 
+        /// # Returns
+        /// 
+        /// Signature - Standardized signature
+        fn convert_to_signature(self: @ContractState, _signature: Bytes) -> Signature {
+            let (_, r) = _signature.read_u256(0);
+            let (_, s) = _signature.read_u256(32);
+            let (_, v) = _signature.read_u8(64);
+            signature_from_vrs(v.try_into().unwrap(), r, s)
+        }
 
-    fn convert_to_signature(_signature: Bytes) -> Signature {
-        let (_, r) = _signature.read_u256(0);
-        let (_, s) = _signature.read_u256(32);
-        let (_, v) = _signature.read_u8(64);
-        signature_from_vrs(v.try_into().unwrap(), r, s)
-    }
-
-
-    fn domain_hash(self: @ContractState, _mailbox_address: ContractAddress, _domain: u32) -> u256 {
-        let felt_address: felt252 = _mailbox_address.into();
-        let mut input: Array<ByteData> = array![
-            ByteData { value: _domain.into(), size: u64_word_size(_domain.into()).into() },
-            ByteData {
-                value: felt_address.into(), size: u256_word_size(felt_address.into()).into()
-            },
-            ByteData { value: HYPERLANE_ANNOUNCEMENT.into(), size: 22 }
-        ];
-        reverse_endianness(compute_keccak(input.span()))
-    }
-
-
-    fn find_validators_index(self: @ContractState, _validator: EthAddress) -> Option<EthAddress> {
-        let mut current_validator: EthAddress = 0.try_into().unwrap();
-        loop {
-            let next_validator = self.validators.read(current_validator);
-            if next_validator == _validator {
-                break Option::Some(current_validator);
-            } else if next_validator == 0.try_into().unwrap() {
-                break Option::None(());
+        /// Returns the domain separator used in validator announcements.
+        fn domain_hash(self: @ContractState, _mailbox_address: ContractAddress, _domain: u32) -> u256 {
+            let felt_address: felt252 = _mailbox_address.into();
+            let mut input: Array<ByteData> = array![
+                ByteData { value: _domain.into(), size: u64_word_size(_domain.into()).into() },
+                ByteData {
+                    value: felt_address.into(), size: u256_word_size(felt_address.into()).into()
+                },
+                ByteData { value: HYPERLANE_ANNOUNCEMENT.into(), size: 22 }
+            ];
+            reverse_endianness(compute_keccak(input.span()))
+        }
+        /// Helper: finds the index associated to a given validator, if found
+        /// Dev: Chained list (EthereumAddress -> EthereumAddress)
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_validator` - The validator to consider
+        /// 
+        /// # Returns 
+        /// 
+        /// EthAddress - the index of the validator in the Storage Map
+        fn find_validators_index(
+            self: @ContractState, _validator: EthAddress
+        ) -> Option<EthAddress> {
+            let mut current_validator: EthAddress = 0.try_into().unwrap();
+            loop {
+                let next_validator = self.validators.read(current_validator);
+                if next_validator == _validator {
+                    break Option::Some(current_validator);
+                } else if next_validator == 0.try_into().unwrap() {
+                    break Option::None;
+                }
+                current_validator = next_validator;
             }
-            current_validator = next_validator;
+        }
+
+        /// Helper: finds the last stored validator
+        fn find_last_validator(self: @ContractState) -> EthAddress {
+            let mut current_validator = self.validators.read(0.try_into().unwrap());
+            loop {
+                let next_validator = self.validators.read(current_validator);
+                if next_validator == 0.try_into().unwrap() {
+                    break current_validator;
+                }
+                current_validator = next_validator;
+            }
+        }
+
+        // Helper: builds a span of validators from the storage map
+        fn build_validators_array(self: @ContractState) -> Span<EthAddress> {
+            let mut index = 0.try_into().unwrap();
+            let mut validators = array![];
+            loop {
+                let validator = self.validators.read(index);
+                if (validator == 0.try_into().unwrap()) {
+                    break ();
+                }
+                validators.append(validator);
+                index = validator;
+            };
+
+            validators.span()
+        }
+    }
+}
+
+
+
+#[starknet::contract]
+pub mod validator_announce {
+    use alexandria_bytes::{Bytes, BytesTrait};
+    use alexandria_data_structures::array_ext::ArrayTraitExt;
+    use core::poseidon::poseidon_hash_span;
+    use hyperlane_starknet::contracts::client::mailboxclient_component::{
+        MailboxclientComponent, MailboxclientComponent::MailboxClientInternalImpl,
+        MailboxclientComponent::MailboxClientImpl
+    };
+    use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::HYPERLANE_ANNOUNCEMENT;
+    use hyperlane_starknet::interfaces::{
+        IMailboxClientDispatcher, IMailboxClientDispatcherTrait, IValidatorAnnounce
+    };
+    use hyperlane_starknet::utils::keccak256::{
+        reverse_endianness, to_eth_signature, compute_keccak, ByteData, u256_word_size,
+        u64_word_size, HASH_SIZE, bool_is_eth_signature_valid
+    };
+    use hyperlane_starknet::utils::store_arrays::StoreFelt252Array;
+    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
+    use starknet::{
+        ContractAddress, ClassHash, EthAddress, secp256_trait::{Signature, signature_from_vrs}
+    };
+
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+    component!(path: MailboxclientComponent, storage: mailboxclient, event: MailboxclientEvent);
+
+    #[abi(embed_v0)]
+    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        mailboxclient: MailboxclientComponent::Storage,
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        upgradeable: UpgradeableComponent::Storage,
+        storage_location_len : LegacyMap::<EthAddress, u256>,
+        storage_locations: LegacyMap::<(EthAddress, u256), Array<felt252>>,
+        replay_protection: LegacyMap::<felt252, bool>,
+        validators: LegacyMap::<EthAddress, EthAddress>,
+    }
+
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        ValidatorAnnouncement: ValidatorAnnouncement,
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        UpgradeableEvent: UpgradeableComponent::Event,
+        #[flat]
+        MailboxclientEvent: MailboxclientComponent::Event,
+    }
+
+    #[derive(starknet::Event, Drop)]
+    pub struct ValidatorAnnouncement {
+        pub validator: EthAddress,
+        pub storage_location: Span<felt252>
+    }
+
+    pub mod Errors {
+        pub const REPLAY_PROTECTION_ERROR: felt252 = 'Announce already occured';
+        pub const WRONG_SIGNER: felt252 = 'Wrong signer';
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, _mailbox: ContractAddress) {
+        self.mailboxclient.initialize(_mailbox);
+    }
+
+
+    #[abi(embed_v0)]
+    impl Upgradeable of IUpgradeable<ContractState> {
+        /// Upgrades the contract to a new implementation.
+        /// Callable only by the owner
+        /// 
+        /// # Arguments
+        ///
+        /// * `new_class_hash` - The class hash of the new implementation.
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            self.ownable.assert_only_owner();
+            self.upgradeable._upgrade(new_class_hash);
         }
     }
 
-    fn find_last_validator(self: @ContractState) -> EthAddress {
-        let mut current_validator = self.validators.read(0.try_into().unwrap());
-        loop {
-            let next_validator = self.validators.read(current_validator);
-            if next_validator == 0.try_into().unwrap() {
-                break current_validator;
-            }
-            current_validator = next_validator;
+    #[abi(embed_v0)]
+    impl IValidatorAnnonceImpl of IValidatorAnnounce<ContractState> {
+        /// Announces a validator signature storage location
+        /// Dev: reverts if announce already occured or if wrong signer
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_validator` - The validator to consider
+        /// * - `_storage_location` - Information encoding the location of signed
+        /// * - `_signature` -The signed validator announcement
+        /// 
+        /// # Returns 
+        /// 
+        /// boolean -  True upon success
+        fn announce(
+            ref self: ContractState,
+            _validator: EthAddress,
+            _storage_location: Array<felt252>,
+            _signature: Bytes
+        ) -> bool {
+            let felt252_validator: felt252 = _validator.into();
+            let mut _input: Array<u256> = array![felt252_validator.into()];
+            let mut u256_storage_location: Array<u256> = array![];
+            let mut cur_idx = 0;
+            let span_storage_location = _storage_location.span();
+            loop {
+                if (cur_idx == span_storage_location.len()) {
+                    break ();
+                }
+                u256_storage_location.append((*span_storage_location.at(cur_idx)).into());
+                cur_idx += 1;
+            };
+            let replay_id = poseidon_hash_span(
+                array![felt252_validator].concat(@_storage_location).span()
+            );
+            assert(!self.replay_protection.read(replay_id), Errors::REPLAY_PROTECTION_ERROR);
+            let announcement_digest = self.get_announcement_digest(u256_storage_location);
+            let signature: Signature = self.convert_to_signature(_signature);
+            assert(
+                bool_is_eth_signature_valid(announcement_digest, signature, _validator),
+                Errors::WRONG_SIGNER
+            );
+            match self.find_validators_index(_validator) {
+                Option::Some => {},
+                Option::None => {
+                    let last_validator = self.find_last_validator();
+                    self.validators.write(last_validator, _validator);
+                }
+            };
+            let mut validator_len = self.storage_location_len.read(_validator);
+            self.storage_locations.write((_validator, validator_len), _storage_location);
+            self.storage_location_len.write(_validator, validator_len +1);
+            self.replay_protection.write(replay_id, true);
+            self
+                .emit(
+                    ValidatorAnnouncement {
+                        validator: _validator, storage_location: span_storage_location
+                    }
+                );
+            true
+        }
+
+
+        /// Returns a list of all announced storage locations
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_validators` - The span of validators to get registrations for
+        /// 
+        /// # Returns 
+        /// 
+        /// Span<Span<felt252>> -  A list of registered storage metadata
+        fn get_announced_storage_locations(
+            self: @ContractState, mut _validators: Span<EthAddress>
+        ) -> Span<Span<Array<felt252>>> {
+            let mut metadata = array![];
+            loop {
+                match _validators.pop_front() {
+                    Option::Some(validator) => {
+                        let mut cur_idx = 0;
+                        let validator_len = self.storage_location_len.read(*validator);
+                        let mut validator_metadata = array![];
+                        loop{
+                            if (cur_idx == validator_len){
+                                break();
+                            }
+                            validator_metadata.append(self.storage_locations.read((*validator,cur_idx)));
+                            cur_idx +=1;
+                        };
+                        metadata.append(validator_metadata.span())
+                    },
+                    Option::None => { break (); }
+                }
+            };
+            metadata.span()
+        }
+
+        /// Returns a list of validators that have made announcements
+        fn get_announced_validators(self: @ContractState) -> Span<EthAddress> {
+            self.build_validators_array()
+        }
+
+
+        /// Returns the digest validators are expected to sign when signing announcements.
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_storage_location` - Storage location as array of u256
+        /// 
+        /// # Returns 
+        /// 
+        /// u256 -  The digest of the announcement.
+        fn get_announcement_digest(
+            self: @ContractState, mut _storage_location: Array<u256>
+        ) -> u256 {
+            let domain_hash = self.domain_hash();
+            let mut byte_data_storage_location = array![];
+            loop {
+                match _storage_location.pop_front() {
+                    Option::Some(storage) => {
+                        byte_data_storage_location
+                            .append(
+                                ByteData { value: storage, size: u256_word_size(storage).into() }
+                            );
+                    },
+                    Option::None => { break (); }
+                }
+            };
+            let hash = reverse_endianness(
+                compute_keccak(
+                    array![ByteData { value: domain_hash.into(), size: HASH_SIZE }]
+                        .concat(@byte_data_storage_location)
+                        .span()
+                )
+            );
+            to_eth_signature(hash)
         }
     }
 
-    fn build_validators_array(self: @ContractState) -> Span<EthAddress> {
-        let mut index = 0.try_into().unwrap();
-        let mut validators = array![];
-        loop {
-            let validator = self.validators.read(index);
-            if (validator == 0.try_into().unwrap()) {
-                break ();
-            }
-            validators.append(validator);
-            index = validator;
-        };
+    #[generate_trait]
+    pub impl ValidatorAnnounceInternalImpl of InternalTrait {
+        /// Converts a byte signature into a standard singature format (see Signature structure)
+        /// 
+        /// # Arguments
+        /// 
+        /// * - ` _signature` - The byte encoded Signature
+        /// 
+        /// # Returns
+        /// 
+        /// Signature - Standardized signature
+        fn convert_to_signature(self: @ContractState, _signature: Bytes) -> Signature {
+            let (_, r) = _signature.read_u256(0);
+            let (_, s) = _signature.read_u256(32);
+            let (_, v) = _signature.read_u8(64);
+            signature_from_vrs(v.try_into().unwrap(), r, s)
+        }
 
-        validators.span()
+        /// Returns the domain separator used in validator announcements.
+        fn domain_hash(self: @ContractState) -> u256 {
+            let mailbox_address: felt252 = self.mailboxclient.mailbox().try_into().unwrap();
+            let mut input: Array<ByteData> = array![
+                ByteData {
+                    value: self.mailboxclient.get_local_domain().into(),
+                    size: u64_word_size(self.mailboxclient.get_local_domain().into()).into()
+                },
+                ByteData {
+                    value: mailbox_address.try_into().unwrap(),
+                    size: u256_word_size(mailbox_address.try_into().unwrap()).into()
+                },
+                ByteData { value: HYPERLANE_ANNOUNCEMENT.into(), size: 22 }
+            ];
+            reverse_endianness(compute_keccak(input.span()))
+        }
+
+        /// Helper: finds the index associated to a given validator, if found
+        /// Dev: Chained list (EthereumAddress -> EthereumAddress)
+        /// 
+        /// # Arguments
+        /// 
+        /// * - `_validator` - The validator to consider
+        /// 
+        /// # Returns 
+        /// 
+        /// EthAddress - the index of the validator in the Storage Map
+        fn find_validators_index(
+            self: @ContractState, _validator: EthAddress
+        ) -> Option<EthAddress> {
+            let mut current_validator: EthAddress = 0.try_into().unwrap();
+            loop {
+                let next_validator = self.validators.read(current_validator);
+                if next_validator == _validator {
+                    break Option::Some(current_validator);
+                } else if next_validator == 0.try_into().unwrap() {
+                    break Option::None;
+                }
+                current_validator = next_validator;
+            }
+        }
+
+        /// Helper: finds the last stored validator
+        fn find_last_validator(self: @ContractState) -> EthAddress {
+            let mut current_validator = self.validators.read(0.try_into().unwrap());
+            loop {
+                let next_validator = self.validators.read(current_validator);
+                if next_validator == 0.try_into().unwrap() {
+                    break current_validator;
+                }
+                current_validator = next_validator;
+            }
+        }
+
+        // Helper: builds a span of validators from the storage map
+        fn build_validators_array(self: @ContractState) -> Span<EthAddress> {
+            let mut index = 0.try_into().unwrap();
+            let mut validators = array![];
+            loop {
+                let validator = self.validators.read(index);
+                if (validator == 0.try_into().unwrap()) {
+                    break ();
+                }
+                validators.append(validator);
+                index = validator;
+            };
+
+            validators.span()
+        }
     }
 }

--- a/contracts/src/contracts/mocks/mock_validator_announce.cairo
+++ b/contracts/src/contracts/mocks/mock_validator_announce.cairo
@@ -28,13 +28,13 @@ pub mod mock_validator_announce {
 
     #[storage]
     struct Storage {
-        mailbox: ContractAddress,  // for testing purpose, we set directly the mailbox address here
+        mailbox: ContractAddress, // for testing purpose, we set directly the mailbox address here
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]
         upgradeable: UpgradeableComponent::Storage,
         domain: u32,
-        storage_location_len : LegacyMap::<EthAddress, u256>,
+        storage_location_len: LegacyMap::<EthAddress, u256>,
         storage_locations: LegacyMap::<(EthAddress, u256), Array<felt252>>,
         replay_protection: LegacyMap::<felt252, bool>,
         validators: LegacyMap::<EthAddress, EthAddress>,
@@ -134,7 +134,7 @@ pub mod mock_validator_announce {
             };
             let mut validator_len = self.storage_location_len.read(_validator);
             self.storage_locations.write((_validator, validator_len), _storage_location);
-            self.storage_location_len.write(_validator, validator_len +1);
+            self.storage_location_len.write(_validator, validator_len + 1);
             self.replay_protection.write(replay_id, true);
             self
                 .emit(
@@ -165,12 +165,13 @@ pub mod mock_validator_announce {
                         let mut cur_idx = 0;
                         let validator_len = self.storage_location_len.read(*validator);
                         let mut validator_metadata = array![];
-                        loop{
-                            if (cur_idx == validator_len){
-                                break();
+                        loop {
+                            if (cur_idx == validator_len) {
+                                break ();
                             }
-                            validator_metadata.append(self.storage_locations.read((*validator,cur_idx)));
-                            cur_idx +=1;
+                            validator_metadata
+                                .append(self.storage_locations.read((*validator, cur_idx)));
+                            cur_idx += 1;
                         };
                         metadata.append(validator_metadata.span())
                     },
@@ -243,7 +244,9 @@ pub mod mock_validator_announce {
         }
 
         /// Returns the domain separator used in validator announcements.
-        fn domain_hash(self: @ContractState, _mailbox_address: ContractAddress, _domain: u32) -> u256 {
+        fn domain_hash(
+            self: @ContractState, _mailbox_address: ContractAddress, _domain: u32
+        ) -> u256 {
             let felt_address: felt252 = _mailbox_address.into();
             let mut input: Array<ByteData> = array![
                 ByteData { value: _domain.into(), size: u64_word_size(_domain.into()).into() },
@@ -310,7 +313,6 @@ pub mod mock_validator_announce {
 }
 
 
-
 #[starknet::contract]
 pub mod validator_announce {
     use alexandria_bytes::{Bytes, BytesTrait};
@@ -352,7 +354,7 @@ pub mod validator_announce {
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]
         upgradeable: UpgradeableComponent::Storage,
-        storage_location_len : LegacyMap::<EthAddress, u256>,
+        storage_location_len: LegacyMap::<EthAddress, u256>,
         storage_locations: LegacyMap::<(EthAddress, u256), Array<felt252>>,
         replay_protection: LegacyMap::<felt252, bool>,
         validators: LegacyMap::<EthAddress, EthAddress>,
@@ -453,7 +455,7 @@ pub mod validator_announce {
             };
             let mut validator_len = self.storage_location_len.read(_validator);
             self.storage_locations.write((_validator, validator_len), _storage_location);
-            self.storage_location_len.write(_validator, validator_len +1);
+            self.storage_location_len.write(_validator, validator_len + 1);
             self.replay_protection.write(replay_id, true);
             self
                 .emit(
@@ -484,12 +486,13 @@ pub mod validator_announce {
                         let mut cur_idx = 0;
                         let validator_len = self.storage_location_len.read(*validator);
                         let mut validator_metadata = array![];
-                        loop{
-                            if (cur_idx == validator_len){
-                                break();
+                        loop {
+                            if (cur_idx == validator_len) {
+                                break ();
                             }
-                            validator_metadata.append(self.storage_locations.read((*validator,cur_idx)));
-                            cur_idx +=1;
+                            validator_metadata
+                                .append(self.storage_locations.read((*validator, cur_idx)));
+                            cur_idx += 1;
                         };
                         metadata.append(validator_metadata.span())
                     },

--- a/contracts/src/interfaces.cairo
+++ b/contracts/src/interfaces.cairo
@@ -233,7 +233,7 @@ pub trait IValidatorAnnounce<TContractState> {
 
     fn get_announced_storage_locations(
         self: @TContractState, _validators: Span<EthAddress>
-    ) -> Span<Span<felt252>>;
+    ) -> Span<Span<Array<felt252>>>;
 
     fn announce(
         ref self: TContractState,
@@ -251,7 +251,7 @@ pub trait IMockValidatorAnnounce<TContractState> {
 
     fn get_announced_storage_locations(
         self: @TContractState, _validators: Span<EthAddress>
-    ) -> Span<Span<felt252>>;
+    ) -> Span<Span<Array<felt252>>>;
 
     fn announce(
         ref self: TContractState,

--- a/contracts/src/tests/test_validator_announce.cairo
+++ b/contracts/src/tests/test_validator_announce.cairo
@@ -44,7 +44,6 @@ fn test_announce() {
 
 #[test]
 fn test_double_announce() {
-
     let mailbox_address = contract_address_const::<
         0x0228c4f640b613dba2107cabf930564bbdb1b4e2d283ba1843b91e6327f09f8e
     >();
@@ -62,20 +61,21 @@ fn test_double_announce() {
     signature.append_u256(0x8e3c967ab6a3b9f93bb4242de0306510e688ea3db08d4e1590714aef8600f5f1);
     signature.append_u256(0x0f4866a1e36bc4134d9568af5d1d51ea7e51a291789f70799380d2d71f5dbf3d);
     signature.append_u8(0x1);
-    let res = validator_announce.announce(validator_address, _storage_location.clone(), signature.clone());
+    let res = validator_announce
+        .announce(validator_address, _storage_location.clone(), signature.clone());
     assert_eq!(res, true);
-    let mut _storage_location_2 : Array<felt252> = array![
+    let mut _storage_location_2: Array<felt252> = array![
         90954189295124463684969781689350429239725285131197301894846683156275291225,
         180946006308525359965345158532346553211983108462325076142963585023296502126,
         276191619276790668637754154763775604
     ];
-    let res = validator_announce.announce(validator_address, _storage_location_2.clone(), signature);
+    let res = validator_announce
+        .announce(validator_address, _storage_location_2.clone(), signature);
     let validators = validator_announce.get_announced_validators();
     assert(validators == array![validator_address].span(), 'validator array mismatch');
     let storage_location = validator_announce.get_announced_storage_locations(validators);
     assert((*storage_location.at(0)).at(0) == @_storage_location, 'wrong storage location');
     assert((*storage_location.at(0)).at(1) == @_storage_location_2, 'wrong storage location');
-
 }
 #[test]
 #[should_panic(expected: ('Wrong signer',))]

--- a/contracts/src/tests/test_validator_announce.cairo
+++ b/contracts/src/tests/test_validator_announce.cairo
@@ -38,9 +38,45 @@ fn test_announce() {
     let validators = validator_announce.get_announced_validators();
     assert(validators == array![validator_address].span(), 'validator array mismatch');
     let storage_location = validator_announce.get_announced_storage_locations(validators);
-    assert(*storage_location.at(0) == _storage_location.span(), 'wrong storage location');
+    assert((*storage_location.at(0)).at(0) == @_storage_location, 'wrong storage location');
 }
 
+
+#[test]
+fn test_double_announce() {
+
+    let mailbox_address = contract_address_const::<
+        0x0228c4f640b613dba2107cabf930564bbdb1b4e2d283ba1843b91e6327f09f8e
+    >();
+
+    let validator_announce = setup_mock_validator_announce(mailbox_address, TEST_STARKNET_DOMAIN);
+    let validator_address: EthAddress = 0xe6076407ca06f2b0a0ec716db2b5361beccdcfa8
+        .try_into()
+        .unwrap();
+    let mut _storage_location: Array<felt252> = array![
+        180946006308525359965345158532346553211983108462325076142963585023296502126,
+        90954189295124463684969781689350429239725285131197301894846683156275291225,
+        276191619276790668637754154763775604
+    ];
+    let mut signature = BytesTrait::new_empty();
+    signature.append_u256(0x8e3c967ab6a3b9f93bb4242de0306510e688ea3db08d4e1590714aef8600f5f1);
+    signature.append_u256(0x0f4866a1e36bc4134d9568af5d1d51ea7e51a291789f70799380d2d71f5dbf3d);
+    signature.append_u8(0x1);
+    let res = validator_announce.announce(validator_address, _storage_location.clone(), signature.clone());
+    assert_eq!(res, true);
+    let mut _storage_location_2 : Array<felt252> = array![
+        90954189295124463684969781689350429239725285131197301894846683156275291225,
+        180946006308525359965345158532346553211983108462325076142963585023296502126,
+        276191619276790668637754154763775604
+    ];
+    let res = validator_announce.announce(validator_address, _storage_location_2.clone(), signature);
+    let validators = validator_announce.get_announced_validators();
+    assert(validators == array![validator_address].span(), 'validator array mismatch');
+    let storage_location = validator_announce.get_announced_storage_locations(validators);
+    assert((*storage_location.at(0)).at(0) == @_storage_location, 'wrong storage location');
+    assert((*storage_location.at(0)).at(1) == @_storage_location_2, 'wrong storage location');
+
+}
 #[test]
 #[should_panic(expected: ('Wrong signer',))]
 fn test_announce_fails_if_wrong_signer() {


### PR DESCRIPTION
Resolves #55 

## Changes 
 - Instead of overwriting the storage, we define a new array with the new elements and store the new array. 
