### PR TITLE
Issue: Fix Integration test test_mailbox_evm_to_strk

### DIFF
--- a/rust/tests/contracts/strk/ism.rs
+++ b/rust/tests/contracts/strk/ism.rs
@@ -2,7 +2,6 @@ use cainome::cairo_serde::ContractAddress;
 use futures::{stream::FuturesUnordered, StreamExt};
 use starknet::{accounts::Account, core::types::FieldElement, macros::felt};
 
-use super::bind::multisig_ism::messageid_multisig_ism;
 use super::bind::multisig_ism:: { messageid_multisig_ism, Bytes, Message };
 use super::bind::routing::domain_routing_ism;
 use crate::validator::{self, TestValidators};
@@ -71,14 +70,6 @@ impl Ism {
 
         let contract = messageid_multisig_ism::new(res.0, owner);
         contract
-            .set_validators(
-                &set.validators
-                    .iter()
-                    .map(|v| v.eth_addr())
-                    .collect::<Vec<_>>(),
-            )
-            .send()
-            .await?;
             .verify(&metadata, &message);
 
         Ok(res.0)

--- a/rust/tests/contracts/strk/ism.rs
+++ b/rust/tests/contracts/strk/ism.rs
@@ -2,7 +2,7 @@ use cainome::cairo_serde::ContractAddress;
 use futures::{stream::FuturesUnordered, StreamExt};
 use starknet::{accounts::Account, core::types::FieldElement, macros::felt};
 
-use super::bind::multisig_ism:: { messageid_multisig_ism, Bytes, Message };
+use super::bind::multisig_ism:: {messageid_multisig_ism, Bytes, Message};
 use super::bind::routing::domain_routing_ism;
 use crate::validator::{self, TestValidators};
 

--- a/rust/tests/mailbox.rs
+++ b/rust/tests/mailbox.rs
@@ -133,8 +133,6 @@ where
     receiver[12..].copy_from_slice(&to.core.msg_receiver.address().0);
     let _sender = from.acc_tester.address();
     let msg_body = b"hello world";
-    let val_u256 = U256::from_bytes_be(&receiver);
-
     let num: u64 = 10000000;
     let mut bytes = [0u8; 32];
     bytes[24..32].copy_from_slice(&num.to_be_bytes());

--- a/rust/tests/mailbox.rs
+++ b/rust/tests/mailbox.rs
@@ -4,7 +4,7 @@ mod contracts;
 mod validator;
 
 use bytes::{BufMut, BytesMut};
-use cainome::cairo_serde::CairoSerde;
+use cainome::cairo_serde:: {CairoSerde, U256};
 use contracts::{
     eth::mailbox::{DispatchFilter, DispatchIdFilter},
     strk::mailbox::{mailbox, Bytes, Dispatch as DispatchEvent, Message},
@@ -133,7 +133,13 @@ where
     receiver[12..].copy_from_slice(&to.core.msg_receiver.address().0);
     let _sender = from.acc_tester.address();
     let msg_body = b"hello world";
+    let val_u256 = U256::from_bytes_be(&receiver);
 
+    let num: u64 = 10000000;
+    let mut bytes = [0u8; 32];
+    bytes[24..32].copy_from_slice(&num.to_be_bytes());
+    let val_u256 = U256::from_bytes_be(&bytes);
+    
     // dispatch
     let mailbox_contract = mailbox::new(from.core.mailbox, &from.acc_tester);
     let dispatch_res = mailbox_contract
@@ -141,6 +147,7 @@ where
             &DOMAIN_EVM,
             &cainome::cairo_serde::ContractAddress(FieldElement::from_bytes_be(&receiver).unwrap()),
             &to_strk_message_bytes(msg_body),
+            &val_u256,
             &None,
             &None,
         )


### PR DESCRIPTION
This PR fix the current integration tests that stop working after the the refactor of the contracts in this commit https://github.com/astraly-labs/hyperlane_starknet/commit/6ef5aa2e0fd1b3491e27f37e18e08bec35c36d00

Solve issue: #26 

- Add  `Bytes`, `Message` from multisig_ism.
- Fix the `deploy_multisig` by  replacing the `.setValidators`  and calling the `verify(&metadata, &message)`  at the end of the test.
- Fix the `send_msg_strk_to_evm` by adding the missing paramter of `mailbox,dispatch`. Err [E0599].

