### PR TITLE
fix: concatenate_input now use bitshift

### DIFF
--- a/contracts/src/utils/keccak256.cairo
+++ b/contracts/src/utils/keccak256.cairo
@@ -1,10 +1,10 @@
+use alexandria_math::BitShift;
 use core::byte_array::{ByteArray, ByteArrayTrait};
 use core::integer::u128_byte_reverse;
 use core::keccak::cairo_keccak;
 use core::to_byte_array::{FormatAsByteArray, AppendFormattedToByteArray};
 use hyperlane_starknet::contracts::libs::checkpoint_lib::checkpoint_lib::HYPERLANE_ANNOUNCEMENT;
 use starknet::{EthAddress, eth_signature::is_eth_signature_valid, secp256_trait::Signature};
-use alexandria_math::BitShift;
 
 pub const ETH_SIGNED_MESSAGE: felt252 = '\x19Ethereum Signed Message:\n32';
 
@@ -386,7 +386,7 @@ fn concatenate_input(bytes: Span<ByteData>) -> ByteArray {
             // Extract the upper 1-byte part
             let up_byte = BitShift::shr(byte.value, 248) & 0xFF;
             output_string.append_word(up_byte.try_into().unwrap(), 1);
-            
+
             // Extract the lower 31-byte part
             let down_byte = byte.value & FELT252_MASK;
             output_string.append_word(down_byte.try_into().unwrap(), 31);

--- a/contracts/src/utils/keccak256.cairo
+++ b/contracts/src/utils/keccak256.cairo
@@ -431,18 +431,6 @@ mod tests {
     }
 
     #[test]
-    fn test_get_last_two_words() {
-        let mut input = Default::default();
-        input.append_word(0x49, 1);
-        input.append_word(0xd35915d0abec0a28990198bb32aa570e681e7eb41a001c0094c7c36a712671, 31);
-        let expected_result = 0x0e681e7eb41a001c0094c7c36a712671;
-        assert_eq!(get_two_last_words(@input, 8), expected_result);
-        let mut input = Default::default();
-        input.append_word('HYPERLANE_ANNOUNCEMENT', 22);
-        let expected_result = 'E_ANNOUNCEMENT';
-        assert_eq!(get_two_last_words(@input, 6), expected_result);
-    }
-    #[test]
     fn test_reverse_endianness() {
         let big_endian_number: u256 = u256 { high: 0x12345678, low: 0 };
         let expected_result: u256 = u256 { high: 0, low: 0x78563412000000000000000000000000 };


### PR DESCRIPTION
Resolves #64 

## Changes

 - Replace the actual mask division by a bitshift operation + AND. 
 - Shadow test
