### PR TITLE
Fix: Integration tests

### DIFF
--- a/contracts/src/contracts/hooks/protocol_fee.cairo
+++ b/contracts/src/contracts/hooks/protocol_fee.cairo
@@ -7,7 +7,9 @@ pub mod protocol_fee {
     use hyperlane_starknet::contracts::libs::message::Message;
     use hyperlane_starknet::interfaces::{IPostDispatchHook, Types, IProtocolFee, ETH_ADDRESS};
     use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
+    use openzeppelin::token::erc20::interface::{
+        ERC20ABI, ERC20ABIDispatcher, ERC20ABIDispatcherTrait
+    };
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
     use starknet::{ContractAddress, contract_address_const, get_contract_address};
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -149,9 +151,9 @@ pub mod protocol_fee {
         /// Collects protocol fees from the contract.
         /// Fees are sent to the beneficary address
         fn collect_protocol_fees(ref self: ContractState) {
-            let token_dispatcher = IERC20Dispatcher { contract_address: self.fee_token.read() };
+            let token_dispatcher = ERC20ABIDispatcher { contract_address: self.fee_token.read() };
             let contract_address = get_contract_address();
-            let balance = token_dispatcher.balance_of(contract_address);
+            let balance = token_dispatcher.balanceOf(contract_address);
             assert(balance != 0, Errors::INSUFFICIENT_BALANCE);
             token_dispatcher.transfer(self.beneficiary.read(), balance);
         }

--- a/contracts/src/contracts/mailbox.cairo
+++ b/contracts/src/contracts/mailbox.cairo
@@ -11,7 +11,9 @@ pub mod mailbox {
         IMessageRecipientDispatcher, IMessageRecipientDispatcherTrait, ETH_ADDRESS,
     };
     use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
+    use openzeppelin::token::erc20::interface::{
+        ERC20ABI, ERC20ABIDispatcher, ERC20ABIDispatcherTrait
+    };
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
     use starknet::{
         ContractAddress, ClassHash, get_caller_address, get_block_number, contract_address_const,
@@ -269,21 +271,21 @@ pub mod mailbox {
             let required_hook = IPostDispatchHookDispatcher {
                 contract_address: required_hook_address
             };
-            let token_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+            let token_dispatcher = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
 
             let mut required_fee = required_hook
                 .quote_dispatch(hook_metadata.clone(), message.clone());
             if (required_fee > 0) {
                 assert(_fee_amount >= required_fee, Errors::NOT_ENOUGH_FEE_PROVIDED);
                 let contract_address = get_contract_address();
-                let user_balance = token_dispatcher.balance_of(caller_address);
+                let user_balance = token_dispatcher.balanceOf(caller_address);
                 assert(user_balance >= _fee_amount, Errors::INSUFFICIENT_BALANCE);
                 assert(
                     token_dispatcher.allowance(caller_address, contract_address) >= _fee_amount,
                     Errors::INSUFFICIENT_ALLOWANCE
                 );
 
-                token_dispatcher.transfer_from(caller_address, required_hook_address, required_fee);
+                token_dispatcher.transferFrom(caller_address, required_hook_address, required_fee);
             }
 
             required_hook.post_dispatch(hook_metadata.clone(), message.clone(), required_fee);
@@ -297,7 +299,7 @@ pub mod mailbox {
                         .post_dispatch(hook_metadata.clone(), message.clone(), default_fee);
                 }
                 if (_fee_amount - required_fee >= default_fee) {
-                    token_dispatcher.transfer_from(caller_address, hook, default_fee);
+                    token_dispatcher.transferFrom(caller_address, hook, default_fee);
                     hook_dispatcher.post_dispatch(hook_metadata, message.clone(), default_fee);
                 }
             }

--- a/contracts/src/contracts/mocks/fee_token.cairo
+++ b/contracts/src/contracts/mocks/fee_token.cairo
@@ -6,9 +6,7 @@ pub mod mock_fee_token {
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
 
     #[abi(embed_v0)]
-    impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC20MetadataImpl = ERC20Component::ERC20MetadataImpl<ContractState>;
+    impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
     impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
     #[storage]
     struct Storage {

--- a/contracts/src/tests/hooks/test_protocol_fee.cairo
+++ b/contracts/src/tests/hooks/test_protocol_fee.cairo
@@ -9,7 +9,7 @@ use hyperlane_starknet::tests::setup::{
     setup_mock_token
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
 use snforge_std::{start_prank, CheatTarget, stop_prank};
 
 
@@ -79,12 +79,12 @@ fn test_collect_protocol_fee() {
 
     // First transfer the token to the contract
     fee_token.transfer(protocol_fee.contract_address, PROTOCOL_FEE);
-    assert_eq!(fee_token.balance_of(protocol_fee.contract_address), PROTOCOL_FEE);
+    assert_eq!(fee_token.balanceOf(protocol_fee.contract_address), PROTOCOL_FEE);
     stop_prank(CheatTarget::One(ownable.contract_address));
 
     protocol_fee.collect_protocol_fees();
-    assert_eq!(fee_token.balance_of(BENEFICIARY()), PROTOCOL_FEE);
-    assert_eq!(fee_token.balance_of(protocol_fee.contract_address), 0);
+    assert_eq!(fee_token.balanceOf(BENEFICIARY()), PROTOCOL_FEE);
+    assert_eq!(fee_token.balanceOf(protocol_fee.contract_address), 0);
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn test_supports_metadata() {
 #[test]
 #[should_panic(expected: ('Invalid metadata variant',))]
 fn test_post_dispatch_fails_if_invalid_variant() {
-    let fee_token = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    let fee_token = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
     let (_, post_dispatch_hook) = setup_protocol_fee();
     let ownable = IOwnableDispatcher { contract_address: fee_token.contract_address };
     let mut metadata = BytesTrait::new_empty();

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -15,7 +15,7 @@ use hyperlane_starknet::interfaces::{
     ETH_ADDRESS
 };
 use openzeppelin::account::utils::signature::EthSignature;
-use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin::token::erc20::interface::{ERC20ABI, ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
 use snforge_std::{
     declare, ContractClassTrait, CheatTarget, EventSpy, EventAssertions, spy_events, SpyOn
 };
@@ -543,7 +543,7 @@ pub fn get_merkle_message_and_signature() -> (u256, Array<felt252>, Array<EthSig
     (msg_hash, validators_array, signatures)
 }
 
-pub fn setup_mock_token() -> IERC20Dispatcher {
+pub fn setup_mock_token() -> ERC20ABIDispatcher {
     let fee_token_class = declare("mock_fee_token").unwrap();
     let (fee_token_addr, _) = fee_token_class
         .deploy_at(
@@ -551,7 +551,7 @@ pub fn setup_mock_token() -> IERC20Dispatcher {
             ETH_ADDRESS()
         )
         .unwrap();
-    IERC20Dispatcher { contract_address: fee_token_addr }
+    ERC20ABIDispatcher { contract_address: fee_token_addr }
 }
 
 pub fn setup_protocol_fee() -> (IProtocolFeeDispatcher, IPostDispatchHookDispatcher) {

--- a/contracts/src/tests/test_mailbox.cairo
+++ b/contracts/src/tests/test_mailbox.cairo
@@ -13,7 +13,7 @@ use hyperlane_starknet::tests::setup::{
 };
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin::token::erc20::interface::{ERC20ABI, ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
 use snforge_std::cheatcodes::events::EventAssertions;
 use snforge_std::{start_prank, CheatTarget, stop_prank};
 
@@ -176,7 +176,7 @@ fn test_dispatch_with_protocol_fee_hook() {
         Option::Some(protocol_fee_hook.contract_address),
         Option::Some(mock_hook.contract_address)
     );
-    let erc20_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    let erc20_dispatcher = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
     let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     erc20_dispatcher.approve(MAILBOX(), PROTOCOL_FEE);
@@ -229,7 +229,7 @@ fn test_dispatch_with_protocol_fee_hook() {
         );
 
     // balance check 
-    assert_eq!(erc20_dispatcher.balance_of(OWNER()), INITIAL_SUPPLY - PROTOCOL_FEE);
+    assert_eq!(erc20_dispatcher.balanceOf(OWNER()), INITIAL_SUPPLY - PROTOCOL_FEE);
     assert(mailbox.get_latest_dispatched_id() == message_id, 'Failed to fetch latest id');
 }
 
@@ -243,7 +243,7 @@ fn test_dispatch_with_two_fee_hook() {
         Option::Some(protocol_fee_hook.contract_address),
         Option::Some(mock_hook.contract_address)
     );
-    let erc20_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    let erc20_dispatcher = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
     let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     // (mock_fee_hook consummes 3 * PROTOCOL_FEE)
@@ -297,7 +297,7 @@ fn test_dispatch_with_two_fee_hook() {
         );
 
     // balance check
-    assert_eq!(erc20_dispatcher.balance_of(OWNER()), INITIAL_SUPPLY - 4 * PROTOCOL_FEE);
+    assert_eq!(erc20_dispatcher.balanceOf(OWNER()), INITIAL_SUPPLY - 4 * PROTOCOL_FEE);
     assert(mailbox.get_latest_dispatched_id() == message_id, 'Failed to fetch latest id');
 }
 
@@ -315,7 +315,7 @@ fn test_dispatch_with_protocol_fee_hook_fails_if_provided_fee_lower_than_require
     let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     // We transfer some token to the new owner
-    let erc20_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    let erc20_dispatcher = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
     erc20_dispatcher.transfer(NEW_OWNER(), PROTOCOL_FEE - 10);
 
     // The new owner has has PROTOCOL_FEE -10 tokens so the required hook post dispatch fails
@@ -355,7 +355,7 @@ fn test_dispatch_with_protocol_fee_hook_fails_if_user_balance_lower_than_fee_amo
     let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     // We transfer some token to the new owner
-    let erc20_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    let erc20_dispatcher = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
     erc20_dispatcher.transfer(NEW_OWNER(), PROTOCOL_FEE - 10);
 
     // The new owner has has PROTOCOL_FEE -10 tokens so the required hook post dispatch fails
@@ -397,7 +397,7 @@ fn test_dispatch_with_protocol_fee_hook_fails_if_insufficient_allowance() {
     let ownable = IOwnableDispatcher { contract_address: ETH_ADDRESS() };
     start_prank(CheatTarget::One(ownable.contract_address), OWNER());
     // We transfer some token to the new owner
-    let erc20_dispatcher = IERC20Dispatcher { contract_address: ETH_ADDRESS() };
+    let erc20_dispatcher = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
     erc20_dispatcher.transfer(NEW_OWNER(), PROTOCOL_FEE);
 
     // The new owner has has PROTOCOL_FEE -10 tokens so the required hook post dispatch fails

--- a/rust/abis/FastHypERC20Collateral.json
+++ b/rust/abis/FastHypERC20Collateral.json
@@ -589,7 +589,7 @@
             "name": "wrappedToken",
             "outputs": [
                 {
-                    "internalType": "contract IERC20",
+                    "internalType": "contract ERC20ABI",
                     "name": "",
                     "type": "address"
                 }

--- a/rust/tests/contracts/eth/bind/mod.rs
+++ b/rust/tests/contracts/eth/bind/mod.rs
@@ -5,8 +5,8 @@ pub mod fast_hyp_erc20_collateral;
 #[allow(clippy::all)]
 pub mod mailbox;
 #[allow(clippy::all)]
+pub mod test_merkle_tree_hook;
+#[allow(clippy::all)]
 pub mod test_mock_ism;
 #[allow(clippy::all)]
 pub mod test_mock_msg_receiver;
-#[allow(clippy::all)]
-pub mod test_merkle_tree_hook;

--- a/rust/tests/contracts/strk/ism.rs
+++ b/rust/tests/contracts/strk/ism.rs
@@ -37,7 +37,6 @@ impl Ism {
 
 impl Ism {
     async fn deploy_mock(codes: &Codes, deployer: &StarknetAccount) -> eyre::Result<FieldElement> {
-        println!("mock ism address: {}", codes.test_mock_ism);
         let res = deploy_contract(codes.test_mock_ism, vec![], deployer).await;
         Ok(res.0)
     }

--- a/rust/tests/mailbox.rs
+++ b/rust/tests/mailbox.rs
@@ -141,6 +141,7 @@ where
             &DOMAIN_EVM,
             &cainome::cairo_serde::ContractAddress(FieldElement::from_bytes_be(&receiver).unwrap()),
             &to_strk_message_bytes(msg_body),
+            &cainome::cairo_serde::U256 { low: 0, high: 0 },
             &None,
             &None,
         )
@@ -235,7 +236,6 @@ async fn test_mailbox_strk_to_evm() -> eyre::Result<()> {
 
     // init eth env
     let anvil = eth::setup_env(DOMAIN_EVM).await?;
-
     let _ = send_msg_strk_to_evm(&strk, &anvil).await?;
 
     Ok(())


### PR DESCRIPTION
Resolves #75 

## Changes

 - Add `fee_amount` as parameter for the `dispatch` function. 
 - Add validators span as constructors for the ism definition
 - Katana supports CamelCase function definition, thus we had to change the current erc20 interface to match this expectation. 
