### PR TITLE
Audit: additional check for aggregation module parameter

### DIFF
--- a/contracts/src/contracts/isms/aggregation/aggregation.cairo
+++ b/contracts/src/contracts/isms/aggregation/aggregation.cairo
@@ -52,7 +52,7 @@ pub mod aggregation {
     #[constructor]
     fn constructor(ref self: ContractState, _owner: ContractAddress, _modules: Span<felt252>) {
         self.ownable.initializer(_owner);
-        assert(_modules.len() < 255, Errors::TOO_MANY_MODULES_PROVIDED);
+        assert(_modules.len() < 256, Errors::TOO_MANY_MODULES_PROVIDED);
         self.set_modules(_modules);
     }
 

--- a/contracts/src/contracts/isms/aggregation/aggregation.cairo
+++ b/contracts/src/contracts/isms/aggregation/aggregation.cairo
@@ -52,7 +52,7 @@ pub mod aggregation {
     #[constructor]
     fn constructor(ref self: ContractState, _owner: ContractAddress, _modules: Span<felt252>) {
         self.ownable.initializer(_owner);
-        assert(_modules.len()<255, Errors::TOO_MANY_MODULES_PROVIDED);
+        assert(_modules.len() < 255, Errors::TOO_MANY_MODULES_PROVIDED);
         self.set_modules(_modules);
     }
 

--- a/contracts/src/contracts/isms/aggregation/aggregation.cairo
+++ b/contracts/src/contracts/isms/aggregation/aggregation.cairo
@@ -46,11 +46,13 @@ pub mod aggregation {
         pub const THRESHOLD_NOT_SET: felt252 = 'Threshold not set';
         pub const MODULES_ALREADY_STORED: felt252 = 'Modules already stored';
         pub const NO_MODULES_PROVIDED: felt252 = 'No modules provided';
+        pub const TOO_MANY_MODULES_PROVIDED: felt252 = 'Too many modules provided';
     }
 
     #[constructor]
     fn constructor(ref self: ContractState, _owner: ContractAddress, _modules: Span<felt252>) {
         self.ownable.initializer(_owner);
+        assert(_modules.len()<255, Errors::TOO_MANY_MODULES_PROVIDED);
         self.set_modules(_modules);
     }
 

--- a/contracts/src/tests/isms/test_aggregation.cairo
+++ b/contracts/src/tests/isms/test_aggregation.cairo
@@ -37,15 +37,15 @@ fn test_aggregation_set_threshold() {
 
 #[test]
 #[should_panic]
-fn test_aggregation_initialize_with_too_many_modules(){
+fn test_aggregation_initialize_with_too_many_modules() {
     let mut modules = array![];
     let mut cur_idx = 0;
-    loop{
+    loop {
         if (cur_idx == 256) {
             break;
         }
         modules.append('module_1'.into());
-        cur_idx +=1;
+        cur_idx += 1;
     };
     setup_aggregation(modules.span());
 }

--- a/contracts/src/tests/isms/test_aggregation.cairo
+++ b/contracts/src/tests/isms/test_aggregation.cairo
@@ -41,7 +41,7 @@ fn test_aggregation_initialize_with_too_many_modules() {
     let mut modules = array![];
     let mut cur_idx = 0;
     loop {
-        if (cur_idx == 255) {
+        if (cur_idx == 256) {
             break;
         }
         modules.append('module_1'.into());

--- a/contracts/src/tests/isms/test_aggregation.cairo
+++ b/contracts/src/tests/isms/test_aggregation.cairo
@@ -36,6 +36,22 @@ fn test_aggregation_set_threshold() {
 }
 
 #[test]
+#[should_panic]
+fn test_aggregation_initialize_with_too_many_modules(){
+    let mut modules = array![];
+    let mut cur_idx = 0;
+    loop{
+        if (cur_idx == 256) {
+            break;
+        }
+        modules.append('module_1'.into());
+        cur_idx +=1;
+    };
+    setup_aggregation(modules.span());
+}
+
+
+#[test]
 #[should_panic(expected: ('Threshold not set',))]
 fn test_aggregation_verify_fails_if_treshold_not_set() {
     let aggregation = setup_aggregation(MODULES());

--- a/contracts/src/tests/isms/test_aggregation.cairo
+++ b/contracts/src/tests/isms/test_aggregation.cairo
@@ -41,7 +41,7 @@ fn test_aggregation_initialize_with_too_many_modules() {
     let mut modules = array![];
     let mut cur_idx = 0;
     loop {
-        if (cur_idx == 256) {
+        if (cur_idx == 255) {
             break;
         }
         modules.append('module_1'.into());


### PR DESCRIPTION
## Best practice

 - Add a check at the constructor level to make sure that the module length is lower than 255, to avoid overflow on the `verify` function.