### PR TITLE
Add CI Workflow to Automatically Label and Tag PRs for feat-token-extensions Branch

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,37 @@
+name: Label PRs for feat-token-extensions
+
+on:
+  pull_request:
+    branches:
+      - feat-token-extensions
+
+jobs:
+  tag-and-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up GitHub CLI
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install GitHub CLI
+        run: |
+          npm install -g @actions/github-script
+
+      - name: Add label to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['feat-token-extensions']
+            })
+
+      - name: Add Tag to PR Title
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "feat-token-extensions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   artifact:
@@ -12,11 +12,13 @@ jobs:
       pull-requests: write
     name: artifact
     runs-on: ubuntu-latest
-    env: 
+    env:
       working-directory: ./contracts
     steps:
       - uses: actions/checkout@v4
       - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.6.5"
       - name: Build contracts
         working-directory: ${{ env.working-directory}}
         run: scarb build
@@ -41,7 +43,7 @@ jobs:
           cd ..
           sha256sum hyperlane-starknet-${{ github.ref_name }}.zip > hyperlane-starknet-${{ github.ref_name }}.CHECKSUM
           md5sum hyperlane-starknet-${{ github.ref_name }}.zip > hyperlane-starknet-${{ github.ref_name }}.CHECKSUM.MD5
-  
+
       - name: Find zip files
         working-directory: ${{ env.working-directory}}
         run: |
@@ -55,5 +57,3 @@ jobs:
             ./contracts/hyperlane-starknet-${{ github.ref_name }}.zip
             ./contracts/hyperlane-starknet-${{ github.ref_name }}.CHECKSUM
             ./contracts/hyperlane-starknet-${{ github.ref_name }}.CHECKSUM.MD5
-
-            

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
       - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.6.5"
 
       - name: Build contracts
         run: |
@@ -29,7 +31,7 @@ jobs:
       - name: Install dojoup
         run: |
           curl -L https://install.dojoengine.org | bash
-      
+
       - name: Install dojo
         run: |-
           /home/runner/.config/.dojo/bin/dojoup -v 0.7.0-alpha.2
@@ -53,9 +55,7 @@ jobs:
       - name: run katana
         run: |
           katana -b 1000 &
-          
+
       - name: Run strk -> evm test
         run: |
           cd rust && cargo test -- test_mailbox_strk_to_evm
-
-        

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,17 @@ on:
 jobs:
   contracts:
     runs-on: ubuntu-latest
-    env: 
+    env:
       working-directory: ./contracts
     steps:
       - uses: actions/checkout@v3
-      
+
       - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.6.5"
       - uses: foundry-rs/setup-snfoundry@v3
         with:
-          starknet-foundry-version: '0.22.0'
+          starknet-foundry-version: "0.22.0"
       - working-directory: ${{ env.working-directory}}
         run: scarb fmt --check
 
@@ -29,6 +31,3 @@ jobs:
         run: scarb build
       - working-directory: ${{ env.working-directory}}
         run: snforge test
-
-
-      


### PR DESCRIPTION
GitHub Actions workflow that automatically labels and tags pull requests (PRs) targeting the feat-token-extensions branch. The goal is to ensure that any PRs related to the feat-token-extensions branch are properly tagged and highlighted for easier identification and management.

Also added scarb version to other ci since it seems that it started to run with cairo 2.7.0 by default