### PR TITLE
Add CASM files to release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: ${{ env.working-directory}}
         run: |
           mkdir -p filtered_artifacts
-          find ./target/dev -type f -name '*.contract_class.json' -exec cp {} filtered_artifacts/ \;
+          find ./target/dev -type f \( -name '*.contract_class.json' -o -name '*.compiled_contract_class.json' \) -exec cp {} filtered_artifacts/ \;
       - name: Generate checksums
         working-directory: ${{ env.working-directory}}
         run: |


### PR DESCRIPTION
## Description
This PR adds `.compiled_contract_class.json` (CASM) files to our release artifacts. These files are essential for contract deployments on StarkNet, as they contain the compiled Cairo Assembly code required by the network.

## Changes
- Modified the release workflow to include both `.contract_class.json` and `.compiled_contract_class.json` files
- Maintains existing checksum and packaging functionality

## Why
CASM files are required for contract deployments on StarkNet. Including them in our release artifacts ensures that users have all necessary files for deployment without needing to recompile the contracts.