### PR TITLE
fix standart_hook_metadata::format_metadata-Bytes size

### DIFF
--- a/cairo/crates/contracts/src/hooks/libs/standard_hook_metadata.cairo
+++ b/cairo/crates/contracts/src/hooks/libs/standard_hook_metadata.cairo
@@ -23,7 +23,7 @@ pub mod standard_hook_metadata {
     const GAS_LIMIT_OFFSET: u8 = 34;
     const REFUND_ADDRESS_OFFSET: u8 = 66;
     const MIN_METADATA_LENGTH: u256 = 98;
-
+    const U128_NUMBER_OF_BYTES: usize = 16;
     pub const VARIANT: u8 = 1;
 
     #[generate_trait]
@@ -140,7 +140,7 @@ pub mod standard_hook_metadata {
                 refund_address_u256.high
             ];
 
-            let mut formatted_metadata = BytesTrait::new(data.len(), data);
+            let mut formatted_metadata = BytesTrait::new(data.len() * U128_NUMBER_OF_BYTES, data);
             formatted_metadata.concat(@custom_metadata);
             formatted_metadata
         }

--- a/cairo/crates/contracts/src/mailbox.cairo
+++ b/cairo/crates/contracts/src/mailbox.cairo
@@ -255,7 +255,7 @@ pub mod mailbox {
                 Option::Some(hook_metadata) => {
                     let mut sanitized_bytes_metadata = BytesTrait::new_empty();
                     sanitized_bytes_metadata.concat(@hook_metadata);
-                    assert( // what does this exactly checks
+                    assert(
                         sanitized_bytes_metadata == hook_metadata,
                         Errors::SIZE_DOES_NOT_MATCH_METADATA
                     );
@@ -516,4 +516,3 @@ pub mod mailbox {
         )
     }
 }
-


### PR DESCRIPTION
Problem:
-  Bytes size has been set to size of u128 array rather than number of Bytes in u128 array. 
 
Fix:
- Size setted to size of u128 array multiplied by number of bytes u128 has (16 byte)
